### PR TITLE
Add ID to recent endpoint

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
 
   def recentpostsapi
     posts = Rails.cache.fetch("last-posts", :expires_in => 30.seconds) do
-      Post.joins(:site).select("posts.title, posts.link, sites.site_logo").order(:created_at).last(100)
+      Post.joins(:site).select("posts.id, posts.title, posts.link, sites.site_logo").order(:created_at).last(100)
     end
 
     posts = posts.last([params[:size].to_i, 100].min).reverse


### PR DESCRIPTION
Currently `id` is `null` in the returned JSON - change this to actually returning the ID.