### PR TITLE
Use site favicon.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>metasmoke</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= favicon_link_tag       'favicon.ico' %>
+  <%= favicon_link_tag       '/favicon.ico' %>
   <%= javascript_include_tag "//www.google.com/jsapi", "chartkick" %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Use the new site favicon, *not* one in the `images/` folder.