### PR TITLE
Review link & feedback API

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,10 @@
             <li class='<%= controller.class == ReviewController ? "active" : "" %>'>
               <%= link_to review_path do %>
                 review
-                <span class="badge"><%= Post.includes(:feedbacks).where( :feedbacks => { :post_id => nil }).count %></span>
+                <% review_items = Post.includes(:feedbacks).where( :feedbacks => { :post_id => nil }).count %>
+                <% if review_items > 0 %>
+                  <span class="badge"><%= review_items %></span>
+                <% end %>
               <% end %>
             </li>
           <% end %>
@@ -58,7 +61,7 @@
               </ul>
 
             </li>
-          <% end %> 
+          <% end %>
           <% if CurrentCommit.present? %>
             <li><a href="https://github.com/Charcoal-SE/metasmoke/commit/<%= CurrentCommit %>"><code><%= CurrentCommit %></code></a></li>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   get "reason/:id", to: "reasons#show"
 
   get "posts/recent.json", to: "posts#recentpostsapi"
+  post "posts/add_feedback", to: "review#add_feedback"
 
   root to: "dashboard#index"
 


### PR DESCRIPTION
- Only show the review count badge if there are review items.
- Add a `posts/add_feedback` POST route for semantics (it just sends it to `review#add_feedback`, but since API feedback won't technically come from review, having this route makes my semantic brain happy).