### PR TITLE
Revert 8fed87932ec180ea285663fa505d4296af5ad69f

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,8 +22,7 @@ class PostsController < ApplicationController
 
   def recentpostsapi
     posts = Rails.cache.fetch("last-posts", :expires_in => 30.seconds) do
-      Post.joins(:site).joins(:feedbacks).where('feedbacks.post_id' => 'posts.id').where('feedbacks.user_id' => current_user.id)
-        .select("posts.id, posts.title, posts.link, posts.created_at, sites.site_logo, feedbacks.feedback_type").order(:created_at).last(100)
+      Post.joins(:site).select("posts.id, posts.title, posts.link, posts.created_at, sites.site_logo").order(:created_at).last(100)
     end
 
     posts.each do |p|


### PR DESCRIPTION
Turns out the last PR did break things after all, namely the recent posts API. Hotfix!