### PR TITLE
Bust reason cache on feedback removal

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -24,6 +24,11 @@ class FeedbacksController < ApplicationController
     raise ActionController::RoutingError.new('Not Found') if current_user.nil? or not current_user.is_admin?
 
     f = Feedback.find params[:id]
+    
+    f.post.reasons.each do |reason|
+      expire_fragment(reason)
+    end
+    
     f.destroy
 
     redirect_to clear_post_feedback_path(f.post_id)


### PR DESCRIPTION
Admins clearing feedback currently doesn't clear the reason cache, so dashboard colour bars stay at the same levels.