### PR TITLE
Fix reason input bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@ $(document).on('ready page:load', function() {
   $(".admin-report").click(function(ev) {
     ev.preventDefault();
     var reason = prompt("Why does this post need admin attention?");
+    if(reason === null) return;
     $.ajax({
       'type': 'POST',
       'url': '/posts/needs_admin',


### PR DESCRIPTION
Post no longer gets reported if you click Cancel on the reason input prompt.