### PR TITLE
Added blurb on MS and added disclaimer

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,3 +1,7 @@
+<p>Metasmoke is a mirror of posts caught by <a href="https://github.com/Charcoal-SE/SmokeDetector">SmokeDetector</a>, a project by <a href="https://github.com/Charcoal-SE">the Charcoal team</a>. Neither Metasmoke, SmokeDetector, nor the people behind them are affiliated with or sponsored by Stack Exchange, Inc.</p>
+
+<hr>
+
 <p>
   <strong><%= @reasons.count %></strong>
   <%= "filter".pluralize(@reasons.count) %> have caught


### PR DESCRIPTION
For background, read from [here](http://chat.stackexchange.com/transcript/message/32615209#32615209) onwards.

The full text should appear as follows above a horizontal line at the top of the MS homepage:

> Metasmoke is a mirror of posts caught by [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector), a project by [the Charcoal team](https://github.com/Charcoal-SE). Neither Metasmoke, SmokeDetector, nor the people behind them are affiliated with or sponsored by Stack Exchange, Inc.