### PR TITLE
configure MiniProfiler to require authorization

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Configure MiniProfiler to require authorization.
+Rack::MiniProfiler.config.authorization_mode = :whitelist
+
 module Metasmoke
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
This summer, we blacklisted some of MiniProfiler’s `pp` modes for security reasons.  I just discovered I could *sometimes* access those on [metasmoke.erwaysoftware.com](//metasmoke.erwaysoftware.com), and when running MS locally on my machine, I could *always* access them.  

Some debugging showed MiniProfiler ran whether or not `authorize_request` was called.  [This answer on SO](//stackoverflow.com/a/15897326/3476191) says that MiniProfiler doesn’t care about `authorize_request` unless `authorization_mode` is set to `:whitelist`, so I did that in `application.rb`.