### PR TITLE
Admin tools for revoking Smokey access

### DIFF
--- a/app/assets/javascripts/smoke_detectors.coffee
+++ b/app/assets/javascripts/smoke_detectors.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/smoke_detectors.scss
+++ b/app/assets/stylesheets/smoke_detectors.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the SmokeDetectors controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/smoke_detectors_controller.rb
+++ b/app/controllers/smoke_detectors_controller.rb
@@ -1,0 +1,23 @@
+class SmokeDetectorsController < ApplicationController
+  before_action :authenticate_user!, :except => [:audits]
+  before_action :verify_admin, :except => [:audits]
+  before_action :set_smoke_detector, :except => [:audits]
+
+  def destroy
+    if @smoke_detector.destroy
+      flash[:success] = "Removed SmokeDetector key for #{@smoke_detector.location}"
+    else
+      flash[:danger] = "Can't remove key. If Undo's gone rogue, start running."
+    end
+    redirect_to url_for(:controller => :status, :action => :index)
+  end
+
+  def audits
+    @audits = Audited::Audit.where(:auditable_type => "SmokeDetector").includes(:auditable, :user).order('created_at DESC').paginate(:page => params[:page], :per_page => 100)
+  end
+
+  private
+  def set_smoke_detector
+    @smoke_detector = SmokeDetector.find params[:id]
+  end
+end

--- a/app/helpers/smoke_detectors_helper.rb
+++ b/app/helpers/smoke_detectors_helper.rb
@@ -1,0 +1,2 @@
+module SmokeDetectorsHelper
+end

--- a/app/models/smoke_detector.rb
+++ b/app/models/smoke_detector.rb
@@ -1,4 +1,6 @@
 class SmokeDetector < ApplicationRecord
+  audited :on => [:destroy]
+
   belongs_to :user
   has_many :statistics
 

--- a/app/views/smoke_detectors/audits.html.erb
+++ b/app/views/smoke_detectors/audits.html.erb
@@ -1,0 +1,19 @@
+<h3>SmokeDetectors Audit</h3>
+
+<table class="table">
+  <tr>
+    <th>User</th>
+    <th>Action</th>
+    <th>Location</th>
+    <th>At</th>
+  </tr>
+
+  <% @audits.each do |audit| %>
+      <tr>
+        <td><%= audit.user.try(:username) %></td>
+        <td><%= audit.action %></td>
+        <td><code><%= audit.audited_changes['location'] %></code></td>
+        <td><span data-livestamp="<%= audit.created_at.to_i %>" title="<%= audit.created_at %>"></span></td>
+      </tr>
+  <% end %>
+</table>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -6,6 +6,9 @@
   <tr>
     <th>Name</th>
     <th>Last Ping</th>
+    <% if user_signed_in? && current_user.has_role?(:admin) %>
+      <th></th>
+    <% end %>
   </tr>
 
   <% @statuses.each_with_index do |sd, index| %>
@@ -16,6 +19,10 @@
     <% end %>
       <td><%= link_to sd.location, smoke_detector_statistics_path(sd.id) %></td>
       <td class="status-<%= sd.status_color %>"><%= sd.last_ping %> (<%= time_ago_in_words(sd.last_ping, include_seconds: true)%> ago)</td>
+      <% if user_signed_in? && current_user.has_role?(:admin) %>
+        <td><%= link_to "De-authorize", url_for(:controller => :smoke_detectors, :action => :destroy, :id => sd.id), :class => "text-danger",
+                :data => {:confirm => "This will be logged, and cannot be undone. Sure?"}, :method => :delete %></td>
+      <% end %>
     </tr>
   <% end %>
 </table>
@@ -23,3 +30,7 @@
 <% if @statuses.to_a.index { |s| s.last_ping < 1.hour.ago } %>
   <a href="#" class="expand-status-table">Toggle hidden</a>
 <% end %>
+
+<br/>
+
+<%= link_to "Audits", url_for(:controller => :smoke_detectors, :action => :audits) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Rails.application.routes.draw do
 
   get "status", to: "status#index"
   get "smoke_detector/:id/statistics", to: "statistics#index", as: :smoke_detector_statistics
+  delete 'smoke_detector/:id', :to => 'smoke_detectors#destroy'
+  get 'smoke_detector/audits', :to => 'smoke_detectors#audits'
   post "statistics.json", to: "statistics#create"
 
   get "users", to: 'admin#users'

--- a/test/controllers/smoke_detectors_controller_test.rb
+++ b/test/controllers/smoke_detectors_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SmokeDetectorsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This gives admins the ability to destroy SmokeDetector records.

Context: third vuln identified on https://docs.google.com/document/d/1voGyl3BUA1JHJ0pR2Mf9E5-wmIDUFC1G8HcThiS7B1k/edit

Destroys are audited, and the audits are linked from StatusController#index.