### PR TITLE
Add link to new API key

### DIFF
--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -31,3 +31,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= link_to "New API key", admin_new_key_url %>


### PR DESCRIPTION
Currently you have to know the URL to create one; this should make it more user-friendly