### PR TITLE
Add a hover with the exact time

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -39,7 +39,7 @@
         <td><%= statistic.posts_scanned %></td>
         <td><%= statistic.post_scan_rate %></td>
         <td><%= statistic.api_quota %></td>
-        <td><%= time_ago_in_words statistic.created_at %> ago</td>
+        <td title="<%= statistic.created_at %>"><%= time_ago_in_words statistic.created_at %> ago</td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Adding a hover over the "created at" times, with the exact timing information, will make easier to see when a smoke detector stopped submitting data / otherwise has changed

Notice that this commit is untested, as it's hard to configure Ruby on Rails on Windows