### PR TITLE
Remove blacklist link

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,11 +1,10 @@
 <h3><%= title "Tools" %></h3>
-<p>Someone thought these were useful, at some point. I take no responsibility for whether they actually are or not.</p>
+<p>Someone thought these were useful, at some point. We take no responsibility for whether they actually are or not.</p>
 <p>
   <ul>
     <li><a href="/admin/invalidated">Invalidated Feedback</a></li>
     <li><a href="/admin/api_feedback">Feedback via API</a></li>
     <li><a href="/users">User Data</a></li>
-    <li><a href="/blacklist">Blacklist</a></li>
     <% if current_user.try(:has_role?, :admin) %>
       <li><a href="/admin/flagged">Posts with Admin Reports</a></li>
       <li><%= link_to "Ignored Users", admin_ignored_users_path %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,9 +73,6 @@
                   <li><%= link_to 'Logout', destroy_user_session_path, :method => :delete %></li>
                   <li><%= link_to 'Apps', url_for(:controller => '/users', :action => :apps) %></li>
                   <li><a href="/admin">Tools</a></li>
-                  <% if current_user.has_role? :code_admin %>
-                    <li><%= link_to 'Blacklist', url_for(:controller => '/blacklist', :action => :index) %></li>
-                  <% end %>
                   <li><%= link_to 'Feedback', admin_user_feedback_path(:user_id => current_user.id) %></li>
                 </ul>
               </li>


### PR DESCRIPTION
The blacklist functionality on MS has been broken for a long time, and AFAIK there aren't any plans to fix it. 

Until the blacklist functionality on MS is fixed, the link should be removed.