### PR TITLE
Don't show posts without feedback in the false positives autoflag page

### DIFF
--- a/app/controllers/flag_log_controller.rb
+++ b/app/controllers/flag_log_controller.rb
@@ -9,7 +9,7 @@ class FlagLogController < ApplicationController
     end
 
     if params[:filter] == 'fps'
-      @applicable_flag_logs = @applicable_flag_logs.includes(:post).where(:posts => {:is_tp => false}).where(:success => true)
+      @applicable_flag_logs = @applicable_flag_logs.includes(:post).where(:posts => [{:is_fp => true}, {:is_naa => true}]).where(:success => true)
     end
 
     @flag_logs = @applicable_flag_logs.order('flag_logs.created_at DESC, flag_logs.id DESC').includes(:post => [:feedbacks => [:user, :api_key]]).includes(:post => [:reasons]).includes(:user).paginate(:page => params[:page], :per_page => 100)


### PR DESCRIPTION
Currently, if a post doesn't have any feedback it is shown on the [false positives flag logs page](https://metasmoke.erwaysoftware.com/flagging/logs?filter=fps), since `{:is_tp => false}` is true for posts without any feedback. This commit fixes that by only selecting posts with FP or NAA feedback.

The code is untested, but it should work (see [ActiveRecord OR query](http://stackoverflow.com/a/9519600/4622463)).