### PR TITLE
Add username to post partial

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -30,6 +30,10 @@
       <% unless post.created_at.nil? %>
         <span data-livestamp="<%= post.created_at.to_i %>" title="<%= post.created_at %>"></span>
       <% end %>
+      
+      <% unless post.username.nil? %>
+        by <%= post.username %>
+      <% end %>
 
       <% unless post.site_id.nil? %>
         <%= link_to (image_tag @sites[@sites.index { |x| x.id == post.site_id }].site_logo, size: "20"), post.link %>


### PR DESCRIPTION
Suggested by Cerbrus

This change adds a username to the post view which appears on /posts, /search, etc. It should appear like this: `5 mins ago by angussidney [i]` where [i] is the icon.

Untested, but there is no reason why it should not work.