### PR TITLE
Add clarification to max autoflags preferences

### DIFF
--- a/app/views/user_site_settings/_form.html.erb
+++ b/app/views/user_site_settings/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for @preference do |f| %>
   <div class="field">
-    <%= f.label :max_flags, "Maximum autoflags per day" %><br/>
+    <%= f.label :max_flags, "Maximum autoflags per day (per site)" %><br/>
     <%= f.number_field :max_flags, :class => "form-control" %>
   </div><br/>
 


### PR DESCRIPTION
Clarify that the max autoflags setting is *per site*, not across all sites selected in total.

See #106