### PR TITLE
Add admin tools to user dropdown

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -117,3 +117,7 @@
 .se-auth-or-label {
   text-align: center;
 }
+
+.dropdown-indent a {
+  padding-left: 30px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,6 +73,18 @@
                   <li><%= link_to 'Logout', destroy_user_session_path, :method => :delete %></li>
                   <li><%= link_to 'Apps', url_for(:controller => '/users', :action => :apps) %></li>
                   <li><a href="/admin">Tools</a></li>
+                  <li class="dropdown-indent"><a href="/admin/invalidated">Invalidated Feedback</a></li>
+                  <li class="dropdown-indent"><a href="/admin/api_feedback">Feedback via API</a></li>
+                  <li class="dropdown-indent"><a href="/users">User Data</a></li>
+                  <% if current_user.try(:has_role?, :admin) %>
+                    <li class="dropdown-indent"><a href="/admin/flagged">Posts with Admin Reports</a></li>
+                    <li class="dropdown-indent"><%= link_to "Ignored Users", admin_ignored_users_path %></li>
+                    <li class="dropdown-indent"><a href="/admin/keys">API Keys</a></li>
+                    <li class="dropdown-indent"><%= link_to "User Permissions", admin_permissions_path %></li>
+                  <% end %>
+                  <% if current_user.has_role?(:developer) %>
+                    <li class="dropdown-indent"><%= link_to "Production log", url_for(:controller => :developer, :action => :production_log), :class => "text-danger" %></li>
+                  <% end %>
                   <li><%= link_to 'Feedback', admin_user_feedback_path(:user_id => current_user.id) %></li>
                 </ul>
               </li>


### PR DESCRIPTION
This adds the admin tools as indented menu items under “Tools”:

<img width="294" alt="Screenshot" src="https://cloud.githubusercontent.com/assets/25517624/23266974/568e6350-f9b7-11e6-9e38-56398161960a.png">

I could also move the “Tools” item to the bottom of the menu or into a separate dropdown.