### PR TITLE
link to new users' Stack Exchange profiles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,12 @@ class User < ApplicationRecord
   after_create do
     self.add_role :reviewer if self.stack_exchange_account_id.present?
     self.add_role :flagger
-    SmokeDetector.send_message_to_charcoal "New metasmoke user '#{self.username}' created"
+    
+    if self.stack_exchange_account_id.present?
+      SmokeDetector.send_message_to_charcoal "New metasmoke user ['#{self.username}'](//stackexchange.com/users/#{self.stack_exchange_account_id}) created"
+    else
+      SmokeDetector.send_message_to_charcoal "New metasmoke user '#{self.username}' created"
+    end
   end
 
   after_save do


### PR DESCRIPTION
[When announcing the creation of a new Metasmoke user, link to their Stack Exchange profile.](//chat.stackexchange.com/transcript/message/35668689#35668689)

Untested and I barely know what I'm doing, so please review, but I'm pretty sure it will work.

Also, should we link somewhere if they didn't sign up with Stack Exchange?