### PR TITLE
Stop automatically adding reviewer role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,6 @@ class User < ApplicationRecord
 
   # All accounts start with flagger role enabled
   after_create do
-    self.add_role :reviewer if self.stack_exchange_account_id.present?
     self.add_role :flagger
     
     if self.stack_exchange_account_id.present?


### PR DESCRIPTION
Originally, we decided to automatically give the reviewer role to new accounts, as it was assumed that anyone who came across MS would have come across it via Charcoal, and hence they would know the responsibilities of having review rights.

However, with the new Meta post, we have a huge amount of new users who don't know anything about how we classify posts around here. e.g. a new user created FP feedback on an obvious TP post [here](https://metasmoke.erwaysoftware.com/post/58552/feedback/clear) (feedback now cleared)

That's why I suggest that we stop automatically awarding the role.

Potential arguments against & counter arguments:
 - It will end up with more admins being bugged - well, most of the people who are interested in getting Review roles are already asking admins to put them on the Smokey list anyway, so no loss there. Also, the new users who make it to this point would be few and far between
 - Bad feedbacks are rare enough - exactly, and hence easier to miss. More of a reason to disallow reviewing by default. 

Note: if this is merged, I will manually remove the reviewer role from all of the new users