### PR TITLE
Actually select all the fields in the post table

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -21,7 +21,7 @@ class ApiController < ApplicationController
   # Read routes: Posts
 
   def posts
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.where(:id => params[:ids].split(";")).select(select_fields(filter)).order(:id => :desc).joins(:feedbacks).joins(:deletion_logs).includes(:flag_logs => [:user])
     @results = @posts.paginate(:page => params[:page], :per_page => @pagesize)
     @more = has_more?(params[:page], @results.count)
@@ -29,7 +29,7 @@ class ApiController < ApplicationController
   end
 
   def posts_by_feedback
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.all.joins(:feedbacks).where(:feedbacks => { :feedback_type => params[:type] }).select(select_fields(filter)).order(:id => :desc).includes(:feedbacks).includes(:flag_logs => [:user])
     results = @posts.paginate(:page => params[:page], :per_page => @pagesize)
     render :json => { :items => results, :has_more => has_more?(params[:page], results.count) }
@@ -44,21 +44,21 @@ class ApiController < ApplicationController
   end
 
   def posts_by_site
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.joins(:site).where(:sites => { :site_url => params[:site] }).select(select_fields(filter)).order(:id => :desc).includes(:feedbacks).includes(:flag_logs => [:user])
     results = @posts.paginate(:page => params[:page], :per_page => @pagesize)
     render :json => { :items => results, :has_more => has_more?(params[:page], results.count) }
   end
 
   def posts_by_daterange
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.where(:created_at => DateTime.strptime(params[:from_date], '%s')..DateTime.strptime(params[:to_date], '%s')).includes(:feedbacks).includes(:flag_logs => [:user])
     results = @posts.select(select_fields(filter)).order(:id => :desc).paginate(:page => params[:page], :per_page => @pagesize)
     render :json => { :items => results, :has_more => has_more?(params[:page], results.count) }
   end
 
   def undeleted_posts
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.left_outer_joins(:deletion_logs).where(:deletion_logs => { :id => nil }).select(select_fields(filter)).includes(:feedbacks).includes(:flag_logs => [:user])
     results = @posts.order(:id => :desc).paginate(:page => params[:page], :per_page => @pagesize)
     render :json => { :items => results, :has_more => has_more?(params[:page], results.count) }
@@ -84,7 +84,7 @@ class ApiController < ApplicationController
   end
 
   def search_posts
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.all
     if params[:feedback_type].present?
       @posts = @posts.includes(:feedbacks).where(:feedbacks => { :feedback_type => params[:feedback_type] })
@@ -112,7 +112,7 @@ class ApiController < ApplicationController
   end
 
   def reason_posts
-    filter = "\x00\x00\x00\x00\x00\x00\x00\x03sc\xc2\x80\x00\x00\x00\x00\x00"
+    filter = "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x01"
     @posts = Post.joins(:posts_reasons).where(:posts_reasons => { :reason_id => params[:id] }).select(select_fields(filter)).order(:id => :desc)
     results = @posts.paginate(:page => params[:page], :per_page => @pagesize)
     render :json => { :items => results, :has_more => has_more?(params[:page], results.count) }


### PR DESCRIPTION
At the moment, these routes don't return the full content of the post table, most importantly, they [even fail to return the post body](https://chat.stackexchange.com/transcript/message/35695288#35695288)

[According to the documentation](https://github.com/Charcoal-SE/metasmoke/wiki/Posts-by-Date-Range), they should return the post body, and some more fields that aren't send (like the `why` field).

This commit updates the filter from the old weird selection of fields to just select all the fields on the table itself, according to the [filters](https://metasmoke.erwaysoftware.com/api/filters) page.