### PR TITLE
Fix navbar on mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -125,4 +125,12 @@
 .navbar-header {
   display: flex;
   align-items: center;
+  @media (max-width: 768px) {
+    .navbar-brand {
+      flex: 1;
+    }
+    .navbar-toggle {
+      order: 1; // flexbox version of float: right
+    }
+  }
 }


### PR DESCRIPTION
This puts the toggle back on the right.

I broke it when adding the logo.