### PR TITLE
Use all users for third autoflag.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -57,7 +57,7 @@ class Post < ApplicationRecord
           core_count -= post.send_autoflag(user, dry_run, available_user_ids[user.id])
         end
 
-        users.without_role(:core).shuffle.each do |user|
+        users.shuffle.each do |user|
           if other_count <= 0
             break
           end


### PR DESCRIPTION
[Earlier today](http://chat.stackexchange.com/transcript/message/36305325#36305325), we had a case where there was a post on a small site (GIS) which reached the autoflagging threshold for some of the people with lower than default autoflagging thresholds (post weight = 179). However, [the post](https://metasmoke.erwaysoftware.com/post/62007) only recieved 2 autoflags as there were no non-core users with a lowered autoflagging threshold *and* an account on GIS.

This reduces the chance of this issue by picking *anyone* rather than non-core users for the third autoflag. It shouldn't affect the who-gets-the-autoflags ratio too much.

Untested, but should work.