### PR TITLE
Fix right-to-left language issues

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -11,7 +11,7 @@
       <span class="text-muted show-post-body" data-postloaded="<%= preload_post_body.to_s %>" data-postid="<%= post.id %>"><%= (expand_post.present? and expand_post) ? "▼" : "►" %></span>
     <% end %>
 
-    <%= link_to post.title, "/post/" + post.id.to_s %>‭
+    <%= link_to post.title, "/post/" + post.id.to_s %>&#x202D;
 
     <% if not post.feedbacks.empty? %>
       <strong>
@@ -32,7 +32,7 @@
       <% end %>
 
       <% unless post.username.nil? || post.stack_exchange_user.nil? %>
-        by <%= link_to post.username, url_for(:controller => :stack_exchange_users, :action => :show, :id => post.stack_exchange_user.id) %>‭
+        by <%= link_to post.username, url_for(:controller => :stack_exchange_users, :action => :show, :id => post.stack_exchange_user.id) %>&#x202D;
       <% end %>
 
       <% unless post.site_id.nil? %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -11,7 +11,7 @@
       <span class="text-muted show-post-body" data-postloaded="<%= preload_post_body.to_s %>" data-postid="<%= post.id %>"><%= (expand_post.present? and expand_post) ? "▼" : "►" %></span>
     <% end %>
 
-    <%= link_to post.title, "/post/" + post.id.to_s %>
+    <%= link_to post.title, "/post/" + post.id.to_s %>‭
 
     <% if not post.feedbacks.empty? %>
       <strong>
@@ -32,9 +32,9 @@
       <% end %>
 
       <% unless post.username.nil? || post.stack_exchange_user.nil? %>
-        by <%= link_to post.username, url_for(:controller => :stack_exchange_users, :action => :show, :id => post.stack_exchange_user.id) %>
-      <% end %>   
-      
+        by <%= link_to post.username, url_for(:controller => :stack_exchange_users, :action => :show, :id => post.stack_exchange_user.id) %>‭
+      <% end %>
+
       <% unless post.site_id.nil? %>
         <%= link_to (image_tag @sites[@sites.index { |x| x.id == post.site_id }].site_logo, size: "20"), post.link %>
       <% end %>


### PR DESCRIPTION
Fixes a bug where a post containing a right-to-left language title would cause other elements (e.g. weight, feedbacks) to appear on the left rather than the right.