### PR TITLE
Use core users' flags if non-core can't fill quota

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -57,7 +57,8 @@ class Post < ApplicationRecord
           core_count -= post.send_autoflag(user, dry_run, available_user_ids[user.id])
         end
 
-        users.without_role(:core).shuffle.each do |user|
+        # Go through all non-core users first; then add core users at the end. See #146
+        (users.without_role(:core).shuffle + users.with_role(:core).shuffle).each do |user|
           if other_count <= 0
             break
           end


### PR DESCRIPTION
Supersedes and closes #146.

Pretty confident about this one, but requesting review since it's autoflag code.