### PR TITLE
Adds API routes for getting users of various permission groups

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -140,6 +140,61 @@ class ApiController < ApplicationController
 
     render :json => { :items => items }
   end
+  
+  def users_with_reviewer_privs
+    chat_ids = User.reviewers.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
+
+    items = {}
+    ["stackexchange_chat_ids", "stackoverflow_chat_ids", "meta_stackexchange_chat_ids"].each_with_index do |name, index|
+      items[name] = chat_ids.map { |a| a[index] }.select { |n| n.present? }
+    end
+
+    render :json => { :items => items }
+  end
+  
+  def users_with_flagger_privs
+    chat_ids = User.flaggers.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
+
+    items = {}
+    ["stackexchange_chat_ids", "stackoverflow_chat_ids", "meta_stackexchange_chat_ids"].each_with_index do |name, index|
+      items[name] = chat_ids.map { |a| a[index] }.select { |n| n.present? }
+    end
+
+    render :json => { :items => items }
+  end
+  
+  def users_with_core_privs
+    chat_ids = User.cores.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
+
+    items = {}
+    ["stackexchange_chat_ids", "stackoverflow_chat_ids", "meta_stackexchange_chat_ids"].each_with_index do |name, index|
+      items[name] = chat_ids.map { |a| a[index] }.select { |n| n.present? }
+    end
+
+    render :json => { :items => items }
+  end
+  
+  def users_with_admin_privs
+    chat_ids = User.admins.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
+
+    items = {}
+    ["stackexchange_chat_ids", "stackoverflow_chat_ids", "meta_stackexchange_chat_ids"].each_with_index do |name, index|
+      items[name] = chat_ids.map { |a| a[index] }.select { |n| n.present? }
+    end
+
+    render :json => { :items => items }
+  end
+  
+  def users_with_developer_privs
+    chat_ids = User.developers.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
+
+    items = {}
+    ["stackexchange_chat_ids", "stackoverflow_chat_ids", "meta_stackexchange_chat_ids"].each_with_index do |name, index|
+      items[name] = chat_ids.map { |a| a[index] }.select { |n| n.present? }
+    end
+
+    render :json => { :items => items }
+  end
 
   # Read routes: Status
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,26 @@ class User < ApplicationRecord
     Role.where(:name => :code_admin).first.users
   end
 
+  def self.reviewers
+    Role.where(:name => :reviewer).first.users
+  end
+
+  def self.flaggers
+    Role.where(:name => :flagger).first.users
+  end
+
+  def self.cores
+    Role.where(:name => :core).first.users
+  end
+
+  def self.admins
+    Role.where(:name => :admin).first.users
+  end
+
+  def self.developers
+    Role.where(:name => :developer).first.users
+  end  
+  
   def remember_me
     true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,11 @@ Rails.application.routes.draw do
     get  'reason/:id/posts', :to => 'api#reason_posts'
     get  'blacklist', :to => 'api#blacklisted_websites'
     get  'users/code_privileged', :to => 'api#users_with_code_privs'
+    get  'users/reviewer_privileged', :to => 'api#users_with_reviewer_privs'
+    get  'users/flagger_privileged', :to => 'api#users_with_flagger_privs'
+    get  'users/core_privileged', :to => 'api#users_with_core_privs'
+    get  'users/admin_privileged', :to => 'api#users_with_admin_privs'
+    get  'users/developer_privileged', :to => 'api#users_with_developer_privs'
 
     post 'w/post/:id/feedback', :to => 'api#create_feedback'
     post 'w/post/report', :to => 'api#report_post'


### PR DESCRIPTION
This should add API routes for each of the permission groups. It was modeled off the existing `users_with_code_privs`

**Please review this.** This is my first contribution to anything Ruby based.

Refs #167