### PR TITLE
Drop previous recent feedback from user on new feedback

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -30,10 +30,12 @@ class Feedback < ApplicationRecord
   after_create do
     next if user_id.nil?
 
-    post.feedbacks.where(user_id: user_id)
-                  .where('created_at > ?', 24.hours.ago)
-                  .where.not(id: id)
-                  .delete_all
+    num_deleted = post.feedbacks.where(user_id: user_id)
+                                .where('created_at > ?', 24.hours.ago)
+                                .where.not(id: id)
+                                .delete_all
+
+    post.reload.update_feedback_cache if num_deleted > 0
   end
 
   def is_positive?

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -28,7 +28,7 @@ class Feedback < ApplicationRecord
   # and less than a day old
 
   after_create do
-    return if user_id.nil?
+    next if user_id.nil?
 
     post.feedbacks.where(user_id: user_id)
                   .where('created_at > ?', 24.hours.ago)

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -97,4 +97,42 @@ class FeedbacksControllerTest < ActionController::TestCase
 
     assert Post.find(p.id).is_fp
   end
+
+  test "should destroy previous feedback from user created within 24 hours" do
+    p = Post.last
+    p.feedbacks.delete_all
+
+    user_id = User.last.id
+
+    f1 = p.feedbacks.create(user_id: user_id, feedback_type: "tpu-")
+
+    assert p.feedbacks.count == 1
+
+    assert_no_difference "p.feedbacks.count" do
+      f2 = f1.dup
+      f2.feedback_type = "fpu-"
+      f2.save
+    end
+  end
+
+  test "shouldn't destroy other user's previous feedback" do
+    p = Post.last
+    p.feedbacks.delete_all
+
+    user_id = User.last.id
+
+    f1 = p.feedbacks.create(user_id: user_id, feedback_type: "tpu-")
+
+    f1_other_user = f1.dup
+    f1_other_user.user_id = -12
+    f1_other_user.save
+
+    assert p.feedbacks.count == 2
+
+    assert_no_difference "p.feedbacks.count" do
+      f2 = f1.dup
+      f2.feedback_type = "fpu-"
+      f2.save
+    end
+  end
 end


### PR DESCRIPTION
See #166. Pertinent points:

 1. Won't work if we can't associate feedback with a registered user.
 2. Requires the previous feedback to be <24hrs old.
 3. Won't drop previous invalidated or ignored feedback, in order to prevent folks from working around a well-earned block (if that were to happen).

Paging @CalvT, if you're interested.