### PR TITLE
Hide dry runs by default in the flagging timeline

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -53,7 +53,7 @@ class GraphsController < ApplicationController
 
   def flagging_timeline
     render json: [{name: 'Failures', data: FlagLog.auto.where(:success => false).group_by_day(:created_at, range: 1.month.ago.to_date..Time.now).count},
-                  {name: 'Dry runs', data: FlagLog.auto.where(:success => true, :is_dry_run => true).group_by_day(:created_at, range: 1.month.ago.to_date..Time.now).count},
+                  {name: 'Dry runs', visible: false, data: FlagLog.auto.where(:success => true, :is_dry_run => true).group_by_day(:created_at, range: 1.month.ago.to_date..Time.now).count},
                   {name: 'Successes', data: FlagLog.auto.where(:success => true, :is_dry_run => false).group_by_day(:created_at, range: 1.month.ago.to_date..Time.now).count}]
   end
 


### PR DESCRIPTION
We don’t do them any more, and they obscure any errors.