### PR TITLE
Allow runners who are not admins to create smoke detectors

### DIFF
--- a/app/controllers/smoke_detectors_controller.rb
+++ b/app/controllers/smoke_detectors_controller.rb
@@ -2,7 +2,7 @@
 
 class SmokeDetectorsController < ApplicationController
   before_action :authenticate_user!, except: [:audits]
-  before_action :verify_admin, except: [:audits, :force_failover, :mine, :token_regen]
+  before_action :verify_admin, except: [:audits, :force_failover, :mine, :token_regen, :new, :create]
   before_action :verify_code_admin, only: [:force_failover]
   before_action :verify_smoke_detector_runner, only: [:mine, :token_regen, :new, :create]
   before_action :set_smoke_detector, except: [:audits, :mine, :new, :create]


### PR DESCRIPTION
I'm *pretty* sure this is why I was getting that 404 earlier.