### PR TITLE
Change migration versions from 4.1 to 4.2

### DIFF
--- a/db/migrate/20150814212102_devise_create_users.rb
+++ b/db/migrate/20150814212102_devise_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeviseCreateUsers < ActiveRecord::Migration[4.1]
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20150814214547_add_is_approved_to_user.rb
+++ b/db/migrate/20150814214547_add_is_approved_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIsApprovedToUser < ActiveRecord::Migration[4.1]
+class AddIsApprovedToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :is_approved, :bool
   end


### PR DESCRIPTION
The oldest two migrations (`20150814212102_devise_create_users` and `20150814214547_add_is_approved_to_user`) had their version set to 4.1, but [4.2 is the oldest allowed version.](https://stackoverflow.com/a/35302198/3476191)