### PR TITLE
Adds 'Feedbacks Today' count

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -36,6 +36,7 @@ class AdminController < ApplicationController
     @feedback = @feedback.order('feedbacks.id DESC').paginate(page: params[:page], per_page: 100)
     @feedback_count = @feedback.count
     @invalid_count = @feedback.where(is_invalidated: true).count
+    @feedback_count_today = @feedback.where('feedbacks.updated_at > ?', DateTime.now.beginning_of_day).count
   end
 
   def flagged

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -36,7 +36,7 @@ class AdminController < ApplicationController
     @feedback = @feedback.order('feedbacks.id DESC').paginate(page: params[:page], per_page: 100)
     @feedback_count = @feedback.count
     @invalid_count = @feedback.where(is_invalidated: true).count
-    @feedback_count_today = @feedback.where('feedbacks.updated_at > ?', DateTime.now.beginning_of_day).count
+    @feedback_count_today = @feedback.where('feedbacks.updated_at > ?', Date.today).count
   end
 
   def flagged

--- a/app/views/admin/user_feedback.html.erb
+++ b/app/views/admin/user_feedback.html.erb
@@ -1,8 +1,10 @@
 <h3>User Feedback for <%= @user.username %></h3>
 
 <p>
-  <strong><%= @feedback_count %></strong>
-  feedbacks,
+  <span title='<%= @feedback_count_today %> feedbacks today'>
+  	<strong><%= @feedback_count %></strong>
+  	feedbacks,
+  </span>
   <strong><%= @invalid_count %></strong>
   invalidated
   (<strong><%= ((@invalid_count.to_f / @feedback_count.to_f) * 100).round(2) %>%</strong> invalid)


### PR DESCRIPTION
When hovering over total feedbacks, the count of feedbacks you’ve given
today will be displayed in the `title` attribute of the span.