### PR TITLE
Autopull when merging blacklist/watchlist PRs

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -210,7 +210,11 @@ class GithubController < ApplicationController
       end
 
       if !Octokit.client.pull_merged?('Charcoal-SE/SmokeDetector', pr_num)
-        Octokit.client.merge_pull_request('Charcoal-SE/SmokeDetector', pr_num)
+        Octokit.client.merge_pull_request(
+          'Charcoal-SE/SmokeDetector', 
+          pr_num, 
+          'Merge blacklist request ##{pr_num} --autopull'
+        )
         message = "Merged SmokeDetector [##{pr_num}](https://github.com/Charcoal-SE/SmokeDetector/pull/#{pr_num})."
         ActionCable.server.broadcast('smokedetector_messages', message: message)
         render plain: "Merged ##{pr_num}"

--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -211,8 +211,8 @@ class GithubController < ApplicationController
 
       if !Octokit.client.pull_merged?('Charcoal-SE/SmokeDetector', pr_num)
         Octokit.client.merge_pull_request(
-          'Charcoal-SE/SmokeDetector', 
-          pr_num, 
+          'Charcoal-SE/SmokeDetector',
+          pr_num,
           'Merge blacklist request ##{pr_num} --autopull'
         )
         message = "Merged SmokeDetector [##{pr_num}](https://github.com/Charcoal-SE/SmokeDetector/pull/#{pr_num})."


### PR DESCRIPTION
Currently, Metasmoke does not specify a commit message when merging a blacklist PR, so the commit must be manually pulled.  This PR changes the commit message to "Merge blacklist request ##{pr_num} --autopull".

I have not tested this, but it's hopefully simple enough that I didn't break anything.