### PR TITLE
Fix commit message when merging blacklist PRs

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -213,7 +213,7 @@ class GithubController < ApplicationController
         Octokit.client.merge_pull_request(
           'Charcoal-SE/SmokeDetector',
           pr_num,
-          'Merge blacklist request ##{pr_num} --autopull'
+          '--autopull'
         )
         message = "Merged SmokeDetector [##{pr_num}](https://github.com/Charcoal-SE/SmokeDetector/pull/#{pr_num})."
         ActionCable.server.broadcast('smokedetector_messages', message: message)


### PR DESCRIPTION
Apparently, `merge_pull_request`'s `commit_message` is not the first line of the commit message, but the extended commit description.  Furthermore, I used single quotes instead of double quotes, resulting in [this commit message](https://github.com/Charcoal-SE/SmokeDetector/commit/c1dff4d).

Since the PR number is already included in the commit summary, I just changed the description to `--autopull`