### PR TITLE
Allow anyone to view the list of all admins

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -2,7 +2,7 @@
 
 class AnnouncementsController < ApplicationController
   before_action :verify_core
-  before_action :verify_admin, only: [:index, :expire]
+  before_action :verify_admin, only: [:expire]
 
   @markdown_renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
 

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -6,7 +6,7 @@
       <span class="badge">Active</span>
     <% end %>
     <span class="text-muted">Created <%= announcement.created_at %>, expires <%= announcement.expiry %>.</span>
-    <% if announcement.current? %>
+    <% if announcement.current? && current_user&.has_role?(:admin) %>
       <%= link_to "Expire now", announcements_expire_path(announcement), class: "text-danger", method: :post, data: { confirm: "Are you sure? This can't be undone" } %>
     <% end %>
   </p>


### PR DESCRIPTION
This allows anyone to view the page, and only shows the 'expire now' link if they are an admin.

Untested, but it should work.