### PR TITLE
Fix post layout on mobile

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -14,3 +14,7 @@ pre.post-body-pre-block {
   white-space: -o-pre-wrap;    /* Opera 7 */
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
+
+.post-body {
+  clear: both;
+}


### PR DESCRIPTION
The metadata on the right side pushes the end of the code block to the left.