### PR TITLE
Split table to sort active and inactive reasons separately

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,11 +2,15 @@
 
 class DashboardController < ApplicationController
   def index
-    @reasons = Reason.all.joins(:posts)
-                     .group('reasons.id')
-                     .select('reasons.*, count(\'posts.*\') as post_count')
-                     .order('inactive ASC, post_count DESC')
-                     .to_a
+    @inactive_reasons, @active_reasons = [true, false].map do |inactive|
+      Reason.all.joins(:posts)
+            .where("reasons.inactive = #{inactive}")
+            .group('reasons.id')
+            .select('reasons.*, count(\'posts.*\') as post_count')
+            .order('post_count DESC')
+            .to_a
+    end
+    @reasons = Reason.all
     @posts = Post.all
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,7 +4,7 @@ class DashboardController < ApplicationController
   def index
     @inactive_reasons, @active_reasons = [true, false].map do |inactive|
       Reason.all.joins(:posts)
-            .where("reasons.inactive = #{inactive}")
+            .where('reasons.inactive = ?', inactive)
             .group('reasons.id')
             .select('reasons.*, count(\'posts.*\') as post_count')
             .order('post_count DESC')

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -8,7 +8,7 @@
 <table class="table sortable-table" style="margin-top:50px">
   <thead>
     <tr>
-      <th>Active Reason</th>
+      <th>Reason</th>
       <th>Number caught</th>
       <th class='no-sort'>Last caught</th>
       <th>Accuracy</th>
@@ -17,7 +17,7 @@
 
   <tbody>
     <% @active_reasons.each do |reason| %>
-      <tr class="<%= "active text-muted inactive-reason" if reason.inactive %>">
+      <tr class="">
         <td><%= link_to reason.reason_name, "/reason/#{reason.id}" %></td>
         <td data-sort-value="<%= reason.post_count %>"><%= reason.post_count %></td>
         <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), :length => 40, :seperator => ' ') %></td>
@@ -41,7 +41,7 @@
 
   <tbody>
     <% @inactive_reasons.each do |reason| %>
-      <tr class="<%= "active text-muted inactive-reason" if reason.inactive %>">
+      <tr class="active text-muted inactive-reason">
         <td><%= link_to reason.reason_name, "/reason/#{reason.id}" %></td>
         <td data-sort-value="<%= reason.post_count %>"><%= reason.post_count %></td>
         <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), :length => 40, :seperator => ' ') %></td>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -18,9 +18,9 @@
   <tbody>
     <% @active_reasons.each do |reason| %>
       <tr class="">
-        <td><%= link_to reason.reason_name, "/reason/#{reason.id}" %></td>
+        <td><%= link_to reason.reason_name, reason_path(reason) %></td>
         <td data-sort-value="<%= reason.post_count %>"><%= reason.post_count %></td>
-        <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), :length => 40, :seperator => ' ') %></td>
+        <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), length: 40, seperator: ' ') %></td>
         <% cache(reason, skip_digest: true) do %>
           <%= render 'reason_accuracy', reason: reason %>
         <% end %>
@@ -42,9 +42,9 @@
   <tbody>
     <% @inactive_reasons.each do |reason| %>
       <tr class="active text-muted inactive-reason">
-        <td><%= link_to reason.reason_name, "/reason/#{reason.id}" %></td>
+        <td><%= link_to reason.reason_name, reason_path(reason) %></td>
         <td data-sort-value="<%= reason.post_count %>"><%= reason.post_count %></td>
-        <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), :length => 40, :seperator => ' ') %></td>
+        <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), length: 40, seperator: ' ') %></td>
         <% cache(reason, skip_digest: true) do %>
           <%= render 'reason_accuracy', reason: reason %>
         <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -8,7 +8,7 @@
 <table class="table sortable-table" style="margin-top:50px">
   <thead>
     <tr>
-      <th>Reason</th>
+      <th>Active Reason</th>
       <th>Number caught</th>
       <th class='no-sort'>Last caught</th>
       <th>Accuracy</th>
@@ -16,7 +16,31 @@
   </thead>
 
   <tbody>
-    <% @reasons.each do |reason| %>
+    <% @active_reasons.each do |reason| %>
+      <tr class="<%= "active text-muted inactive-reason" if reason.inactive %>">
+        <td><%= link_to reason.reason_name, "/reason/#{reason.id}" %></td>
+        <td data-sort-value="<%= reason.post_count %>"><%= reason.post_count %></td>
+        <td><%= truncate((reason.last_post_title.nil? ? reason.posts.last.title : reason.last_post_title), :length => 40, :seperator => ' ') %></td>
+        <% cache(reason, skip_digest: true) do %>
+          <%= render 'reason_accuracy', reason: reason %>
+        <% end %>
+      </tr>
+    <% end %>
+ </tbody>
+</table>
+
+<table class="table sortable-table" style="margin-top:50px">
+  <thead>
+    <tr>
+      <th>Inactive Reason</th>
+      <th>Number caught</th>
+      <th class='no-sort'>Last caught</th>
+      <th>Accuracy</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @inactive_reasons.each do |reason| %>
       <tr class="<%= "active text-muted inactive-reason" if reason.inactive %>">
         <td><%= link_to reason.reason_name, "/reason/#{reason.id}" %></td>
         <td data-sort-value="<%= reason.post_count %>"><%= reason.post_count %></td>


### PR DESCRIPTION
closes https://github.com/Charcoal-SE/metasmoke/issues/157

1. Active and inactive reasons can be sorted separately.
2. Inactive reasons is below active reason.
3. Assume the 'n' part of  'n filters have caught m posts' should still
display total number of reasons instead of number of active reasons.

Note: the column widths of the two tables are not guaranteed to be the
same since the widths depend on the length of contents for active and
inactive reasons, respectively.  From a practical standpoint, the width
should normalize to be about the same given enough content.

![peek 2017-10-12 17-56](https://user-images.githubusercontent.com/1740566/31521301-eb8f1f4c-af76-11e7-9e46-b8f1f5542c38.gif)
