### PR TITLE
Fix Posts by Site API route param to use site_domain instead of site_url

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -62,7 +62,7 @@ class APIController < ApplicationController
   def posts_by_site
     filter = 'AAAAAAAAAAPHx4AAAAAAAUA='
     @posts = Post.joins(:site)
-                 .where(sites: { site_url: params[:site] })
+                 .where(sites: { site_domain: params[:site] })
                  .select(select_fields(filter))
                  .order(id: :desc)
                  .includes(:feedbacks)

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -88,14 +88,14 @@ class APIControllerTest < ActionController::TestCase
 
   test 'should get posts by site' do
     get :posts_by_site, params: {
-      site: Post.last.site.site_url,
+      site: Post.last.site.site_domain,
       key: api_keys(:one).key,
       filter: "\x00\x00\x00\x00\x00\x00\x00\x03\xC3\xBF\xC3\xBF\xC2\x80\x00\x00\x00\x00\x00"
     }
 
     assert_response :success
     assert !assigns(:posts).to_a.empty?
-    assert assigns(:posts).select { |p| p.site.site_url == Post.last.site.site_url }.count == assigns(:posts).to_a.size
+    assert assigns(:posts).select { |p| p.site.site_domain == Post.last.site.site_domain }.count == assigns(:posts).to_a.size
   end
 
   # Search tests


### PR DESCRIPTION
PR to fix bug found in https://github.com/Charcoal-SE/metasmoke/issues/226#issuecomment-336497586 while reviewing API documentation for #226.