### PR TITLE
Add edit/delete buttons to show domain tags

### DIFF
--- a/app/views/domain_tags/show.html.erb
+++ b/app/views/domain_tags/show.html.erb
@@ -4,6 +4,17 @@
 <% else %>
   <p><em>No description.</em></p>
 <% end %>
+<% if user_signed_in? && (current_user.has_role?(:core) || current_user.has_role?(:admin)) %>
+  <p>
+    <% if current_user.has_role?(:core) %>
+      <%= link_to 'Edit', edit_domain_tag_path(@domain) %>
+    <% end %>
+    <% if current_user.has_role?(:admin) %>
+      &middot; <%= link_to 'Delete', destroy_domain_tag_path(@domain), method: :delete,
+                    data: { confirm: 'Are you sure?' }, class: 'text-danger' %>
+    <% end %>
+  </p>
+<% end %>
 
 <h4>Domains tagged with this tag</h4>
 <table class="table table-striped">


### PR DESCRIPTION
As per the request of @tripleee here: https://chat.stackexchange.com/transcript/message/40843345#40843345

> feature request: a link to edit the tag's description when you're looking at a tag's "details" page 

I've used the code [here](https://github.com/Charcoal-SE/metasmoke/blob/master/app/views/spam_domains/show.html.erb#L2-L12) for reference