### PR TITLE
Added api route for all reasons

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -134,6 +134,13 @@ class APIController < ApplicationController
     render json: { items: results, has_more: has_more?(params[:page], results.count) }
   end
 
+  def all_reasons
+    filter = 'AAAAAAAAAAAAABgAAAAAAAA='
+    @reasons = Reason.all.select(select_fields(filter)).order(id: :desc)
+    results = @reasons.paginate(page: params[:page], per_page: @pagesize)
+    render json: { items: results, has_more: has_more?(params[:page], results.count) }
+  end
+
   def reason_posts
     filter = 'AAAAAAAAAAPHx4AAAAAAAUA='
     @posts = Post.joins(:posts_reasons).where(posts_reasons: { reason_id: params[:id] }).select(select_fields(filter)).order(id: :desc)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
     get  'post/:id/feedback', to: 'api#post_feedback'
     get  'post/:id/reasons', to: 'api#post_reasons'
     get  'post/:id/valid_feedback', to: 'api#post_valid_feedback'
+    get  'reasons', to: 'api#all_reasons'
     get  'reasons/:ids', to: 'api#reasons'
     get  'reason/:id/posts', to: 'api#reason_posts'
     get  'blacklist', to: 'api#blacklisted_websites'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,7 @@ every 1.day do
   runner 'ReasonsHelper.calculate_weights_for_flagging'
 end
 
-every 1.day at: "3:30 pm" do
+every 1.day at: '3:30 pm' do
   runner 'SitesHelper.update_sites'
 end
 


### PR DESCRIPTION
Creates `/api/reasons`, which returns all the reasons in the database with the same filter as existed for the reasons by id api route.