### PR TITLE
Enter critical region when performing a merge

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -7,6 +7,8 @@ class GithubController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :verify_github, except: [:update_deploy_to_master, :add_pullapprove_comment]
   before_action :check_if_smokedetector, only: [:add_pullapprove_comment]
+  
+  @@git_mutex = Mutex.new
 
   # Fires whenever a CI service finishes.
   def status_hook
@@ -230,13 +232,15 @@ class GithubController < ApplicationController
       end
 
       if !Octokit.client.pull_merged?('Charcoal-SE/SmokeDetector', pr_num)
-        Dir.chdir('SmokeDetector') do
-          ref = pr[:head][:ref]
+        @@git_mutex.synchronize do
+          Dir.chdir('SmokeDetector') do
+            ref = pr[:head][:ref]
 
-          system 'git fetch origin master; git checkout -B master origin/master'
-          system 'git', 'fetch', 'origin', ref
-          system 'git', 'merge', "origin/#{ref}", '--no-ff', '-m', "Merge pull request ##{pr_num} from Charcoal-SE/#{ref} --autopull"
-          system 'git push origin master'
+            system 'git fetch origin master; git checkout -B master origin/master'
+            system 'git', 'fetch', 'origin', ref
+            system 'git', 'merge', "origin/#{ref}", '--no-ff', '-m', "Merge pull request ##{pr_num} from Charcoal-SE/#{ref} --autopull"
+            system 'git push origin master'
+          end
         end
 
         message = "Merged SmokeDetector [##{pr_num}](https://github.com/Charcoal-SE/SmokeDetector/pull/#{pr_num})."

--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -7,8 +7,8 @@ class GithubController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :verify_github, except: [:update_deploy_to_master, :add_pullapprove_comment]
   before_action :check_if_smokedetector, only: [:add_pullapprove_comment]
-  
-  @@git_mutex = Mutex.new
+
+  @git_mutex = Mutex.new
 
   # Fires whenever a CI service finishes.
   def status_hook


### PR DESCRIPTION
This hasn't happened yet, but in theory if two PRs were approved simultaneously Metasmoke might try to merge one while the other merge was in progress. No harm would be done, since Git would complain about a merge already taking place, but the second PR wouldn't get merged. Instead we should wait on a mutex when trying to merge stuff.