### PR TITLE
API V2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'groupdate', '~> 3.0.0'
 gem 'rubocop', '~> 0.48.1', require: false, group: :test
 gem 'simplecov', require: false, group: :test
 
+gem 'grape', '1.0.0'
+
 # gem 'puma_worker_killer'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
     audited (4.5.0)
       activerecord (>= 4.0, < 5.2)
     awesome_print (1.8.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     backports (3.8.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
@@ -108,6 +112,8 @@ GEM
     chartkick (2.2.4)
     chronic (0.10.2)
     chunky_png (1.3.8)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -118,6 +124,8 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -125,6 +133,7 @@ GEM
       responders
       warden (~> 1.2.3)
     docile (1.1.5)
+    equalizer (0.0.11)
     erubi (1.6.1)
     ethon (0.10.1)
       ffi (>= 1.3.0)
@@ -146,6 +155,13 @@ GEM
       net-http-pipeline
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    grape (1.0.0)
+      activesupport
+      builder
+      mustermann-grape (~> 1.0.0)
+      rack (>= 1.3.0)
+      rack-accept
+      virtus (>= 1.0.0)
     groupdate (3.0.2)
       activesupport (>= 3)
     hashdiff (0.3.4)
@@ -154,6 +170,7 @@ GEM
     httparty (0.15.5)
       multi_xml (>= 0.5.2)
     i18n (0.8.4)
+    ice_nine (0.11.2)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -182,6 +199,9 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.1)
+    mustermann-grape (1.0.0)
+      mustermann (~> 1.0.0)
     mysql2 (0.4.6)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
@@ -202,6 +222,8 @@ GEM
       json
       websocket (~> 1.0)
     rack (2.0.3)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-contrib (1.2.0)
       rack (>= 0.9.1)
     rack-cors (0.4.1)
@@ -307,6 +329,11 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -351,6 +378,7 @@ DEPENDENCIES
   devise
   flamegraph
   foreman
+  grape (= 1.0.0)
   groupdate (~> 3.0.0)
   htmlentities (~> 4.3, >= 4.3.4)
   httparty
@@ -388,4 +416,4 @@ DEPENDENCIES
   will_paginate-bootstrap!
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/app/api/api/announcements_api.rb
+++ b/app/api/api/announcements_api.rb
@@ -1,0 +1,32 @@
+module API
+  class AnnouncementsAPI < API::Base
+    prefix :announcements
+
+    get '/' do
+      std_result Announcement.all.order(id: :desc), filter: 'HNLMH'
+    end
+
+    get 'active' do
+      std_result Announcement.where('expiry > ?', DateTime.now).order(id: :desc), filter: 'HNLMH'
+    end
+
+    get 'expired' do
+      std_result Announcement.where('expiry < ?', DateTime.now).order(id: :desc), filter: 'HNLMH'
+    end
+
+    before do
+      authenticate_user!
+      role :core
+    end
+    params do
+      requires :key, type: String
+      requires :token, type: String
+      requires :text, type: String
+      requires :expiry, type: DateTime
+    end
+    post 'create' do
+      announcement = Announcement.create(text: params[:text], expiry: params[:expiry])
+      single_result announcement
+    end
+  end
+end

--- a/app/api/api/apps_api.rb
+++ b/app/api/api/apps_api.rb
@@ -1,0 +1,9 @@
+module API
+  class AppsAPI < API::Base
+    prefix :apps
+
+    get '/' do
+      std_result APIKey.all.order(id: :desc), filter: 'MMIGHGKIMLJJIMHGNNONNMNMGFNFNJOMMIMLJHNFIH'
+    end
+  end
+end

--- a/app/api/api/base.rb
+++ b/app/api/api/base.rb
@@ -1,0 +1,68 @@
+module API
+  class Base < Grape::API
+    version 'v2.0', using: :accept_version_header
+    prefix :api
+    format :json
+
+    helpers do
+      def current_user
+        @current_user ||= @token.user
+      end
+
+      def authenticate_app!
+        @key = APIKey.find_by key: params[:key]
+        error!({ name: 'missing_key', detail: 'No key was provided or the provided key is invalid.' }, 403) unless @key.present?
+      end
+
+      def authenticate_user!
+        @token = @key.api_tokens.find_by token: params[:token]
+        error!({ name: 'missing_token', detail: 'No token was provided or the provided token is invalid.' }, 401) unless @token.present?
+      end
+
+      def fields(default)
+        @fields ||= Filterator::V2.fields_from_filter(params[:filter] || default)
+      end
+
+      def role(*names)
+        return if current_user.has_any_role?(*names)
+        error!({ name: 'unauthorized', detail: 'The authenticated user does not have the required permissions for this action.' }, 403)
+      end
+
+      def per_page
+        [(params[:per_page] || 10).to_i, 100].min
+      end
+
+      def more?(col, **opts)
+        ctr = if opts[:countable].nil? || opts[:countable] == true
+                col.count
+              else
+                col.to_a.size
+              end
+        ctr > per_page * (params[:page]&.to_i || 1)
+      end
+
+      def paginated(col)
+        col.paginate(page: params[:page], per_page: per_page)
+      end
+
+      def std_result(col, **opts)
+        { items: paginated(col.select(fields(opts[:filter]))), has_more: more?(col, **opts) }
+      end
+
+      def single_result(item, **opts)
+        { items: [item], has_more: false }
+      end
+    end
+
+    before do
+      authenticate_app!
+    end
+
+    mount API::DebugAPI
+    mount API::AnnouncementsAPI
+    mount API::AppsAPI
+    mount API::CommitStatusesAPI
+    mount API::DeletionLogsAPI
+    mount API::DomainTagsAPI
+  end
+end

--- a/app/api/api/commit_statuses_api.rb
+++ b/app/api/api/commit_statuses_api.rb
@@ -1,0 +1,9 @@
+module API
+  class CommitStatusesAPI < API::Base
+    prefix :commit_statuses
+
+    get '/' do
+      std_result CommitStatus.all.order(id: :desc), filter: 'GGLIFMJJOLIGGNFGINNMOFNIGGMMMJKIFGKFJ'
+    end
+  end
+end

--- a/app/api/api/debug_api.rb
+++ b/app/api/api/debug_api.rb
@@ -1,0 +1,9 @@
+module API
+  class DebugAPI < API::Base
+    prefix :debug
+
+    get '/' do
+      { params: params, ts: DateTime.now }
+    end
+  end
+end

--- a/app/api/api/deletion_logs_api.rb
+++ b/app/api/api/deletion_logs_api.rb
@@ -1,0 +1,13 @@
+module API
+  class DeletionLogsAPI < API::Base
+    prefix :deletion_logs
+
+    get '/' do
+      std_result DeletionLog.all.order(id: :desc), filter: 'OFNLKGOKFHJIKOJNIJOOHNILNKMLGIKGLN'
+    end
+
+    get '/post/:id' do
+      std_result DeletionLog.where(post_id: params[:id]).order(id: :desc), filter: 'OFNLKGOKFHJIKOJNIJOOHNILNKMLGIKGLN'
+    end
+  end
+end

--- a/app/api/api/domain_tags_api.rb
+++ b/app/api/api/domain_tags_api.rb
@@ -1,0 +1,17 @@
+module API
+  class DomainTagsAPI < API::Base
+    prefix :domain_tags
+
+    get '/' do
+      std_result DomainTag.all.order(id: :desc), filter: 'NOL'
+    end
+
+    get 'name/:name' do
+      std_result DomainTag.where(name: params[:name]).order(id: :desc), filter: 'NOL'
+    end
+
+    get ':id/domains' do
+      std_result DomainTag.find(params[:id]).spam_domains, filter: 'HN'
+    end
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class APIController < ApplicationController
-  before_action :verify_key, except: [:filter_generator, :api_docs, :filter_fields]
+  before_action :verify_key, except: [:filter_generator, :api_docs, :filter_fields, :calculate_filter]
   before_action :verify_trusted_key, only: [:regex_search]
   before_action :set_pagesize, except: [:filter_generator, :api_docs]
   before_action :verify_write_token, only: [:create_feedback, :report_post, :spam_flag, :add_domain_tag]
@@ -348,6 +348,11 @@ class APIController < ApplicationController
     render json: { success: true, items: results, more_url: api_domain_tags_url(domain) }
   end
 
+  def calculate_filter
+    filter = Filterator::V2.filter_from_fields(params[:fields])
+    render json: { filter: filter }
+  end
+
   private
 
   def verify_key
@@ -388,7 +393,7 @@ class APIController < ApplicationController
   end
 
   def select_fields(default = '')
-    Filterator.fields_from_string(params[:filter] || default)
+    Filterator::V1.fields_from_string(params[:filter] || default)
   end
 
   def verify_trusted_key

--- a/app/helpers/filterator.rb
+++ b/app/helpers/filterator.rb
@@ -1,51 +1,74 @@
 # frozen_string_literal: true
 
-class Filterator
-  # I'm fairly sure most of this class works by magic, rather than by any design.
+module Filterator
+  class V1
+    # I'm fairly sure most of this class works by magic, rather than by any design.
 
-  # This thing turns strings of characters into strings of binary digits, where the binary digits come from the
-  # character ordinals of each character in the string.
-  # For each character, convert its ordinal to binary, pad the result with 0's so it's 8 digits long, and append the
-  # 8 digits generated to an array; that array gets joined into one long string, which is what actually gets stored in
-  # this hash.
-  @generator = Hash.new do |h, k|
-    chars = k.chars
-    mappings = AppConfig['api_field_mappings']
-    h[k] = chars.map.with_index do |c, i|
-      if i < chars.size - 1
-        c.ord.to_s(2).rjust(8, '0')
-      else
-        rem = mappings.size % 8
-        rem = 8 if rem == 0
-        c.ord.to_s(2).rjust(rem, '0')
-      end
-    end.join('')
-  end
-
-  # This takes a Base64-encoded filter string and turns it into an array of database-level qualified database column
-  # names.
-  # Uses @generator to turn the decoded Base64 into a binary string; turns the string into an array of 0's and 1's,
-  # and zips the result together with the API field mappings in config. Selects only the fields that now have a 1 next
-  # to them, and returns the resulting list of field names.
-  def self.fields_from_string(encoded)
-    raw = Base64.decode64(encoded)
-    bitstring = @generator[raw]
-    bits = bitstring.chars.map(&:to_i)
-    AppConfig['api_field_mappings'].zip(bits).map { |k, v| k if v == 1 }.compact
-  end
-
-  # This is precisely the opposite of the previous method: given a list of database-level qualified column names, turns
-  # them into a Base64-encoded filter string.
-  # Creates an array the length of the API field mappings in config, and populates it - for each index, if the field at
-  # that index in the mappings is present in the list of fields passed to this method, the array will be populated with
-  # a 1; 0 if not. Chops the array into groups of 8, parses each group of 8 as a binary number to turn it to decimal,
-  # and then turns the decimals into their respective characters. Finally, Base64 encodes the lot and returns it.
-  def self.string_from_fields(fields)
-    mappings = AppConfig['api_field_mappings']
-    bits = Array.new(mappings.size) do |i|
-      fields.include?(mappings[i]) ? 1 : 0
+    # This thing turns strings of characters into strings of binary digits, where the binary digits come from the
+    # character ordinals of each character in the string.
+    # For each character, convert its ordinal to binary, pad the result with 0's so it's 8 digits long, and append the
+    # 8 digits generated to an array; that array gets joined into one long string, which is what actually gets stored in
+    # this hash.
+    @generator = Hash.new do |h, k|
+      chars = k.chars
+      mappings = AppConfig['api_field_mappings']
+      h[k] = chars.map.with_index do |c, i|
+        if i < chars.size - 1
+          c.ord.to_s(2).rjust(8, '0')
+        else
+          rem = mappings.size % 8
+          rem = 8 if rem == 0
+          c.ord.to_s(2).rjust(rem, '0')
+        end
+      end.join('')
     end
-    raw = bits.each_slice(8).map { |x| x.join('').to_i(2).chr }.join('')
-    Base64.encode64(raw)
+
+    # This takes a Base64-encoded filter string and turns it into an array of database-level qualified database column
+    # names.
+    # Uses @generator to turn the decoded Base64 into a binary string; turns the string into an array of 0's and 1's,
+    # and zips the result together with the API field mappings in config. Selects only the fields that now have a 1 next
+    # to them, and returns the resulting list of field names.
+    def self.fields_from_string(encoded)
+      raw = Base64.decode64(encoded)
+      bitstring = @generator[raw]
+      bits = bitstring.chars.map(&:to_i)
+      AppConfig['api_field_mappings'].zip(bits).map { |k, v| k if v == 1 }.compact
+    end
+
+    # This is precisely the opposite of the previous method: given a list of database-level qualified column names, turns
+    # them into a Base64-encoded filter string.
+    # Creates an array the length of the API field mappings in config, and populates it - for each index, if the field at
+    # that index in the mappings is present in the list of fields passed to this method, the array will be populated with
+    # a 1; 0 if not. Chops the array into groups of 8, parses each group of 8 as a binary number to turn it to decimal,
+    # and then turns the decimals into their respective characters. Finally, Base64 encodes the lot and returns it.
+    def self.string_from_fields(fields)
+      mappings = AppConfig['api_field_mappings']
+      bits = Array.new(mappings.size) do |i|
+        fields.include?(mappings[i]) ? 1 : 0
+      end
+      raw = bits.each_slice(8).map { |x| x.join('').to_i(2).chr }.join('')
+      Base64.encode64(raw)
+    end
+  end
+
+  class V2
+    # This class is slightly less magic than V1.
+    # Filters look like this: HJHGJJKKIIKKNMGOJILKKMMJFLOOKIGNONNMGK
+    # TL;DR: It's a binary bitfield, turned into a decimal integer, and each digit is turned into a character.
+
+    def self.filter_from_fields(fields)
+      mappings = AppConfig['api_field_mappings']
+      bits = Array.new(mappings.size) do |i|
+        fields.include?(mappings[i]) ? 1 : 0
+      end
+      as_int = bits.join.to_i(2)
+      as_int.to_s.chars.map { |c| (c.to_i + 70).chr }.join
+    end
+
+    def self.fields_from_filter(filter)
+      as_int = filter.chars.map { |c| c.ord - 70 }.join.to_i
+      bits = as_int.to_s(2).rjust(AppConfig['api_field_mappings'].size, '0').chars.map { |c| c.to_i }
+      AppConfig['api_field_mappings'].zip(bits).map { |k, v| k if v == 1 }.compact - AppConfig['sensitive_fields']
+    end
   end
 end

--- a/app/javascript/api.js
+++ b/app/javascript/api.js
@@ -8,27 +8,20 @@ const partitionArray = (array, size) => array.map((e, i) => (i % size === 0) ?
 
 onLoad(() => {
   $('#create_filter').on('click', () => {
-    const bits = Array.from($('input[type=checkbox]')).reduce((arr, el) => {
-      const $el = $(el);
-      arr[$el.data('index')] = Number($el.is(':checked'));
-      return arr;
-    }, []);
-
-    const bytes = partitionArray(bits, 8);
-    debug(bits.join(''));
-    debug(bytes.map(x => x.join('')).join(' '));
-    debug(bytes.map(x => parseInt(x.join(''), 2)).join('        '));
-
-    let unsafeFilter = '';
-    for (let i = 0; i < bytes.length; i++) {
-      const nextByte = bytes[i].join('');
-      const charCode = parseInt(nextByte.toString(), 2);
-      unsafeFilter += String.fromCharCode(charCode);
-      debug(nextByte, charCode, unsafeFilter);
-    }
-
-    const filter = btoa(unsafeFilter);
-    debug(filter);
-    window.prompt('Your filter:', filter);
+    const fields = $('label:has(input[type=checkbox]:checked)').toArray().map(el => $(el).text().trim());
+    $.ajax({
+      type: 'POST',
+      url: '/api/filters',
+      data: {
+        fields: fields
+      }
+    })
+    .done(data => {
+      prompt("This is your filter. Copy it and use it as the filter query string parameter on API requests.", data['filter']);
+    })
+    .fail(xhr => {
+      debug(xhr.status);
+      debug(xhr);
+    });
   });
 });

--- a/app/views/api/filter_generator.html.erb
+++ b/app/views/api/filter_generator.html.erb
@@ -10,6 +10,20 @@
   <div class="col-md-4">
     <div class="panel panel-default" id="api_keys">
       <div class="panel-heading">
+        <strong><code>announcements</code></strong>
+      </div>
+      <div class="panel-body">
+        <label><input type="checkbox" data-index="135" id="a_id" /> <code>announcements.id</code></label><br/>
+        <label><input type="checkbox" data-index="136" id="a_text" /> <code>announcements.text</code></label><br/>
+        <label><input type="checkbox" data-index="136" id="a_expiry" /> <code>announcements.expiry</code></label><br/>
+        <label><input type="checkbox" data-index="137" id="a_created_at" /> <code>announcements.created_at</code></label><br/>
+        <label><input type="checkbox" data-index="138" id="a_updated_at" /> <code>announcements.updated_at</code></label><br/>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="panel panel-default" id="api_keys">
+      <div class="panel-heading">
         <strong><code>api_keys</code></strong>
       </div>
       <div class="panel-body">
@@ -40,6 +54,8 @@
       </div>
     </div>
   </div>
+</div>
+<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="blacklisted_websites">
       <div class="panel-heading">
@@ -54,8 +70,6 @@
       </div>
     </div>
   </div>
-</div>
-<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="commit_statuses">
       <div class="panel-heading">
@@ -86,6 +100,22 @@
       </div>
     </div>
   </div>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <div class="panel panel-default" id="deletion_logs">
+      <div class="panel-heading">
+        <strong><code>domain_tags</code></strong>
+      </div>
+      <div class="panel-body">
+        <label><input type="checkbox" data-index="139" id="dt_id" /> <code>domain_tags.id</code></label><br/>
+        <label><input type="checkbox" data-index="140" id="dt_name" /> <code>domain_tags.name</code></label><br/>
+        <label><input type="checkbox" data-index="141" id="dt_description" /> <code>domain_tags.description</code></label><br/>
+        <label><input type="checkbox" data-index="142" id="dt_created_at" /> <code>domain_tags.created_at</code></label><br/>
+        <label><input type="checkbox" data-index="143" id="dt_updated_at" /> <code>domain_tags.updated_at</code></label>
+      </div>
+    </div>
+  </div>
   <div class="col-md-4">
     <div class="panel panel-default" id="feedbacks">
       <div class="panel-heading">
@@ -111,8 +141,6 @@
       </div>
     </div>
   </div>
-</div>
-<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="flags">
       <div class="panel-heading">
@@ -129,6 +157,8 @@
       </div>
     </div>
   </div>
+</div>
+<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="posts">
       <div class="panel-heading">
@@ -159,8 +189,6 @@
       </div>
     </div>
   </div>
-</div>
-<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="posts_reasons">
       <div class="panel-heading">
@@ -185,6 +213,8 @@
       </div>
     </div>
   </div>
+</div>
+<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="roles">
       <div class="panel-heading">
@@ -200,8 +230,6 @@
       </div>
     </div>
   </div>
-</div>
-<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="sites">
       <div class="panel-heading">
@@ -236,6 +264,22 @@
       </div>
     </div>
   </div>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <div class="panel panel-default" id="sites">
+      <div class="panel-heading">
+        <strong><code>spam_domains</code></strong>
+      </div>
+      <div class="panel-body">
+        <label><input type="checkbox" data-index="144" id="spd_id" /> <code>spam_domains.id</code></label><br/>
+        <label><input type="checkbox" data-index="145" id="spd_domain" /> <code>spam_domains.domain</code></label><br/>
+        <label><input type="checkbox" data-index="146" id="spd_whois" /> <code>spam_domains.whois</code></label><br/>
+        <label><input type="checkbox" data-index="147" id="spd_created_at" /> <code>spam_domains.created_at</code></label><br/>
+        <label><input type="checkbox" data-index="148" id="spd_updated_at" /> <code>spam_domains.updated_at</code></label>
+      </div>
+    </div>
+  </div>
   <div class="col-md-4">
     <div class="panel panel-default" id="stack_exchange_users">
       <div class="panel-heading">
@@ -256,8 +300,6 @@
       </div>
     </div>
   </div>
-</div>
-<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="users">
       <div class="panel-heading">
@@ -273,6 +315,8 @@
       </div>
     </div>
   </div>
+</div>
+<div class="row">
   <div class="col-md-4">
     <div class="panel panel-default" id="users_roles">
       <div class="panel-heading">

--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -63,7 +63,7 @@ common: &common
     - feedbacks.chat_user_id
     - feedbacks.created_at
     - feedbacks.updated_at
-    - feedbacks.id # Used to be feedbacks.is_ignored. Keep this as a placeholder so we don't break filters
+    - feedbacks.is_ignored
     - feedbacks.api_key_id
     - feedbacks.chat_host
     - flags.id
@@ -73,12 +73,12 @@ common: &common
     - flags.updated_at
     - flags.is_completed
     - flags.post_id
-    - deleted.deleted
-    - deleted.deleted
-    - deleted.deleted
-    - deleted.deleted
-    - deleted.deleted
-    - deleted.deleted
+    - ignored_users.id
+    - ignored_users.user_name
+    - ignored_users.user_id
+    - ignored_users.created_at
+    - ignored_users.updated_at
+    - ignored_users.is_ignored
     - posts.id
     - posts.title
     - posts.body
@@ -145,6 +145,28 @@ common: &common
     - users_roles.user_id
     - users_roles.role_id
     - posts.deleted_at
+    - posts.revision_count
+    - moderator_sites.id
+    - moderator_sites.user_id
+    - moderator_sites.site_id
+    - moderator_sites.created_at
+    - moderator_sites.updated_at
+    - smoke_detectors.is_standby
+    - announcements.id
+    - announcements.text
+    - announcements.expiry
+    - announcements.created_at
+    - announcements.updated_at
+    - domain_tags.id
+    - domain_tags.name
+    - domain_tags.description
+    - domain_tags.created_at
+    - domain_tags.updated_at
+    - spam_domains.id
+    - spam_domains.domain
+    - spam_domains.whois
+    - spam_domains.created_at
+    - spam_domains.updated_at
   sensitive_fields:
     - api_keys.key
     - api_tokens.code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,8 +149,9 @@ Rails.application.routes.draw do
 
   scope '/api' do
     root to: 'api#api_docs', as: :api_docs
-
     get  'filters', to: 'api#filter_generator'
+    post 'filters', to: 'api#calculate_filter'
+
     get  'filter_fields', to: 'api#filter_fields'
     get  'stats/last_week', to: 'api#spam_last_week'
     get  'stats/detailed_ttd', to: 'api#detailed_ttd'
@@ -271,4 +272,7 @@ Rails.application.routes.draw do
     get  'users/2fa/login', to: 'custom_sessions#verify_2fa'
     post 'users/2fa/login', to: 'custom_sessions#verify_code'
   end
+
+  # This should always be right at the end of this file, so that it doesn't override other routes.
+  mount API::Base => '/api'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,14 +12,14 @@
 
 ActiveRecord::Schema.define(version: 20171031033433) do
 
-  create_table "announcements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "announcements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.text "text"
     t.datetime "expiry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "api_keys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "api_keys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "key", collation: "utf8_unicode_ci"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_id"], name: "index_api_keys_on_user_id"
   end
 
-  create_table "api_tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "api_tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "code", collation: "utf8_unicode_ci"
     t.integer "api_key_id"
     t.integer "user_id"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_id"], name: "index_api_tokens_on_user_id"
   end
 
-  create_table "audits", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "audits", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "auditable_id"
     t.string "auditable_type", collation: "utf8mb4_bin"
     t.integer "associated_id"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_id", "user_type"], name: "user_index", length: { user_type: 191 }
   end
 
-  create_table "commit_statuses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "commit_statuses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "commit_sha", collation: "utf8_unicode_ci"
     t.string "status", collation: "utf8_unicode_ci"
     t.string "commit_message", collation: "utf8_unicode_ci"
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.string "ci_url", collation: "utf8_unicode_ci"
   end
 
-  create_table "deletion_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "deletion_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "post_id"
     t.boolean "is_deleted"
     t.datetime "created_at", null: false
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.integer "spam_domain_id", null: false
   end
 
-  create_table "feedbacks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "feedbacks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "message_link", collation: "utf8_unicode_ci"
     t.string "user_name", collation: "utf8_unicode_ci"
     t.string "user_link", collation: "utf8_unicode_ci"
@@ -114,7 +114,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_name"], name: "by_user_name", length: { user_name: 5 }
   end
 
-  create_table "flag_conditions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "flag_conditions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.boolean "flags_enabled", default: true
     t.integer "min_weight"
     t.integer "max_poster_rep"
@@ -125,12 +125,12 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_id"], name: "index_flag_conditions_on_user_id"
   end
 
-  create_table "flag_conditions_sites", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "flag_conditions_sites", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "flag_condition_id"
     t.integer "site_id"
   end
 
-  create_table "flag_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "flag_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.boolean "success"
     t.text "error_message"
     t.integer "flag_condition_id"
@@ -151,14 +151,14 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_id"], name: "index_flag_logs_on_user_id"
   end
 
-  create_table "flag_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "flag_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name", collation: "utf8mb4_bin"
     t.string "value", collation: "utf8mb4_bin"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "flags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "flags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "reason", collation: "utf8_unicode_ci"
     t.string "user_id", collation: "utf8_unicode_ci"
     t.datetime "created_at", null: false
@@ -168,21 +168,21 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["post_id"], name: "index_flags_on_post_id"
   end
 
-  create_table "github_tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "github_tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "token", collation: "utf8mb4_bin"
     t.datetime "expires"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "moderator_sites", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "moderator_sites", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "user_id"
     t.integer "site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "posts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "posts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "title", collation: "utf8mb4_unicode_ci"
     t.text "body", limit: 16777215, collation: "utf8mb4_unicode_ci"
     t.string "link", collation: "utf8mb4_unicode_ci"
@@ -209,7 +209,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["link"], name: "index_posts_on_link", length: { link: 191 }
   end
 
-  create_table "posts_reasons", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "posts_reasons", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "reason_id"
     t.integer "post_id"
     t.index ["post_id"], name: "index_posts_reasons_on_post_id"
@@ -221,15 +221,15 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.integer "spam_domain_id", null: false
   end
 
-  create_table "reasons", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "reasons", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "reason_name", collation: "utf8_unicode_ci"
-    t.string "last_post_title", collation: "utf8_unicode_ci"
+    t.string "last_post_title", collation: "utf8mb4_unicode_ci"
     t.boolean "inactive", default: false
     t.integer "weight", default: 0
     t.integer "maximum_weight", limit: 1
   end
 
-  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name", collation: "utf8mb4_unicode_ci"
     t.string "resource_type", collation: "utf8mb4_unicode_ci"
     t.integer "resource_id"
@@ -252,12 +252,12 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.datetime "last_users_update"
   end
 
-  create_table "sites_user_site_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "sites_user_site_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "site_id"
     t.integer "user_site_setting_id"
   end
 
-  create_table "smoke_detectors", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "smoke_detectors", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.datetime "last_ping"
     t.string "name", collation: "utf8mb4_unicode_ci"
     t.string "location", collation: "utf8mb4_unicode_ci"
@@ -278,7 +278,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "stack_exchange_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "stack_exchange_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "user_id"
     t.string "username", collation: "utf8mb4_unicode_ci"
     t.datetime "last_api_update"
@@ -291,7 +291,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.integer "site_id"
   end
 
-  create_table "statistics", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "statistics", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "posts_scanned"
     t.integer "smoke_detector_id"
     t.datetime "created_at", null: false
@@ -300,7 +300,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.float "post_scan_rate", limit: 24
   end
 
-  create_table "user_site_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_site_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "max_flags"
     t.integer "flags_used", default: 0
     t.integer "user_id"
@@ -309,7 +309,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["user_id"], name: "index_user_site_settings_on_user_id"
   end
 
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "email", default: "", null: false, collation: "utf8_unicode_ci"
     t.string "encrypted_password", default: "", null: false, collation: "utf8_unicode_ci"
     t.datetime "remember_created_at"
@@ -333,7 +333,7 @@ ActiveRecord::Schema.define(version: 20171031033433) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  create_table "users_roles", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "users_roles", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "user_id"
     t.integer "role_id"
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"

--- a/lib/tasks/grape-routes.rake
+++ b/lib/tasks/grape-routes.rake
@@ -1,0 +1,8 @@
+namespace :grape do
+  desc 'Print grape API routes'
+  task :routes => :environment do
+    API::Base.routes.each do |route|
+      puts "#{route.options[:method]} #{route.path}"
+    end
+  end
+end


### PR DESCRIPTION
Work in progress - don't merge yet. **Config has changed and will need to be added on deploy.**

This is so much nicer than V1.

 - We're using [Grape](https://github.com/ruby-grape/grape) to power this. 1.0.0, because there's [a bug](https://github.com/ruby-grape/grape/issues/1683) in 1.0.1.
 - Filter implementation has changed: filters are better, more stable, and faster. Generator calls the server to generate filters to ensure the generator and server agree on what filters should be, instead of having two implementations of a filter generator (JS and Ruby).
 - API structure is split up by model: the models exposed in the API have an equivalent `{model}_api.rb` file in `app/api/api` (yes, that double `api` directory is necessary).
 - Everything that was possible with V1 should still be possible with V2; V1 should also still be available.

Still to do:
 - Finish creating the API - add an API for every model we want to expose.
 - DOCS!