### PR TITLE
Correctly format links in Post#why (Issue #315)

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,7 +3,7 @@
 module PostsHelper
   def render_links(text)
     raw(text.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
-      i % 2 == 0 ? s : link_to(s, s)
+      i % 2 == 0 ? sanitize(s) : link_to(s, s)
     end.join)
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,7 +2,7 @@
 
 module PostsHelper
   def render_links(text)
-    raw(reason.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
+    raw(text.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
       i % 2 == 0 ? s : link_to(s, s)
     end.join)
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,7 +3,7 @@
 module PostsHelper
   def render_links(text)
     raw(text.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
-      i.even? ? sanitize(s) : link_to(s, s)
+      i.even? ? html_escape(s) : link_to(s, s)
     end.join)
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 module PostsHelper
+  def render_links(text)
+    raw(reason.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
+      i % 2 == 0 ? s : link_to(s, s)
+    end.join)
+  end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,7 +3,7 @@
 module PostsHelper
   def render_links(text)
     raw(text.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
-      i % 2 == 0 ? sanitize(s) : link_to(s, s)
+      i.even? ? sanitize(s) : link_to(s, s)
     end.join)
   end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -84,7 +84,7 @@
 <% end %>
 
 <% if @post.why.present? %>
-  <pre><%= @post.why %></pre>
+  <pre><%= render_links @post.why %></pre>
 <% end %>
 
 <% if user_signed_in? && current_user.api_token.present? && !@post.is_fp && !@post.is_deleted? && Time.now - (@post.created_at || 1.day.ago) <= 1.hour %>


### PR DESCRIPTION
Added a helper to make text links actual link elements and applied it to the rendering of Post#why in the show view for posts. This will close #315.