### PR TITLE
Stopped auto-linking non-metasmoke/non-SE parts of Post#why (Close #320)

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,7 +2,9 @@
 
 module PostsHelper
   def render_links(text)
-    raw(text.split(%r{((?:https?:)?\/{2}[^\)\s]*)}).map.with_index do |s, i|
+    # Don't forget to escape the '.'!
+    permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net m\\.erwaysoftware\\.com]
+    raw(text.split(%r{((?:https?:)?\/{2}(?:#{permitted_sites.join('|')})[^\)\s]*)}).map.with_index do |s, i|
       i.even? ? html_escape(s) : link_to(s, s)
     end.join)
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,8 +2,13 @@
 
 module PostsHelper
   def render_links(text)
-    # Don't forget to escape the '.'!
-    permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net \\w*.\\.stackexchange\\.com m(?:etasmoke)?\\.erwaysoftware\\.com]
+    # Don't forget to escape the '.' because regex!
+    permitted_sites = %w[
+      (?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com
+      mathoverflow\\.net
+      \\w*.\\.stackexchange\\.com
+      m(?:etasmoke)?\\.erwaysoftware\\.com
+    ]
     raw(text.split(%r{((?:https?:)?\/{2}(?:#{permitted_sites.join('|')})[^\)\<\s]*)}).map.with_index do |s, i|
       i.even? ? html_escape(s) : link_to(s, s)
     end.join)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -4,7 +4,7 @@ module PostsHelper
   def render_links(text)
     # Don't forget to escape the '.'!
     permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net \\w*.\\.stackexchange\\.com m(?:etasmoke)?\\.erwaysoftware\\.com]
-    raw(text.split(%r{((?:https?:)?\/{2}(?:#{permitted_sites.join('|')})[^\)\s]*)}).map.with_index do |s, i|
+    raw(text.split(%r{((?:https?:)?\/{2}(?:#{permitted_sites.join('|')})[^\)\<\s]*)}).map.with_index do |s, i|
       i.even? ? html_escape(s) : link_to(s, s)
     end.join)
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,7 +3,7 @@
 module PostsHelper
   def render_links(text)
     # Don't forget to escape the '.'!
-    permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net m(?:etasmoke)?\\.erwaysoftware\\.com]
+    permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net \\w*.\\.stackexchange\\.com m(?:etasmoke)?\\.erwaysoftware\\.com]
     raw(text.split(%r{((?:https?:)?\/{2}(?:#{permitted_sites.join('|')})[^\)\s]*)}).map.with_index do |s, i|
       i.even? ? html_escape(s) : link_to(s, s)
     end.join)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,7 +3,7 @@
 module PostsHelper
   def render_links(text)
     # Don't forget to escape the '.'!
-    permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net m\\.erwaysoftware\\.com]
+    permitted_sites = %w[(?:stackoverflow|superuser|serverfault|askubuntu|stackapps)\\.com mathoverflow\\.net m(?:etasmoke)?\\.erwaysoftware\\.com]
     raw(text.split(%r{((?:https?:)?\/{2}(?:#{permitted_sites.join('|')})[^\)\s]*)}).map.with_index do |s, i|
       i.even? ? html_escape(s) : link_to(s, s)
     end.join)


### PR DESCRIPTION
As per #320 I've fixed my previous changes to now apply only to SE/MS related sites.