### PR TITLE
Fixed error when adding a domain tag which has already been added (Close #267)

### DIFF
--- a/app/controllers/domain_tags_controller.rb
+++ b/app/controllers/domain_tags_controller.rb
@@ -18,7 +18,11 @@ class DomainTagsController < ApplicationController
   def add
     @tag = DomainTag.find_or_create_by name: params[:tag_name]
     @domain = SpamDomain.find params[:domain_id]
-    @domain.domain_tags << @tag
+    if @domain.domain_tags.include? @tag
+      flash[:danger] = "This domain already has the tag '#{@tag.name}'"
+    else
+      @domain.domain_tags << @tag
+    end
     redirect_to spam_domain_path(@domain)
   end
 


### PR DESCRIPTION
Previously, if you attempted to add a domain tag to a domain that already had that tag, you'd get a traceback. Now, you'll simply get a warning stating that the tag was already there.