### PR TITLE
Added question/answer search (Close #124)

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -77,30 +77,13 @@ class SearchController < ApplicationController
       @results = @results.not_autoflagged
     end
 
+    post_type = params[:post_type].try(:downcase).try(:[], 0)
     unmatched = @results.where("NOT( link like '%/q/%' OR link like '%/a/%' )")
-    case params[:post_type].try(:downcase).try(:[], 0)
-    when 'q'
-      @results = @results.where("link like ?", "%/q/%").or(unmatched)
-    when 'a'
-      @results = @results.where("link like ?", "%/a/%").or(unmatched)
-    end
-    # each do |r|
-    #   case r.link.to_s.downcase
-    #   when "/q/"
-    #     questions << r
-    #   when "/a/"
-    #     answers << r
-    #   else
-    #     other << r
-    #   end
-    # end
-
-    # case params[:post_type].try(:downcase).try(:[], 0)
-    # when 'q'
-    #   @results = questions + other
-    # when 'a'
-    #   @results = answers + other
-    # end
+    @results =  if params[:post_type_include_unmatched]
+                  @results.where("link like ?", "%/#{post_type}/%").or(unmatched)
+                else
+                  @results.where("link like ?", "%/#{post_type}/%")
+                end
 
     respond_to do |format|
       format.html do

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -77,6 +77,31 @@ class SearchController < ApplicationController
       @results = @results.not_autoflagged
     end
 
+    unmatched = @results.where("NOT( link like '%/q/%' OR link like '%/a/%' )")
+    case params[:post_type].try(:downcase).try(:[], 0)
+    when 'q'
+      @results = @results.where("link like ?", "%/q/%").or(unmatched)
+    when 'a'
+      @results = @results.where("link like ?", "%/a/%").or(unmatched)
+    end
+    # each do |r|
+    #   case r.link.to_s.downcase
+    #   when "/q/"
+    #     questions << r
+    #   when "/a/"
+    #     answers << r
+    #   else
+    #     other << r
+    #   end
+    # end
+
+    # case params[:post_type].try(:downcase).try(:[], 0)
+    # when 'q'
+    #   @results = questions + other
+    # when 'a'
+    #   @results = answers + other
+    # end
+
     respond_to do |format|
       format.html do
         @counts_by_accuracy_group = @results.group(:is_tp, :is_fp, :is_naa).count

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -77,8 +77,14 @@ class SearchController < ApplicationController
       @results = @results.not_autoflagged
     end
 
-    post_type = params[:post_type].try(:downcase).try(:[], 0)
-    unmatched = @results.where("NOT( link like '%/q/%' OR link like '%/a/%' )")
+
+    post_type = case params[:post_type].try(:downcase).try(:[], 0)
+    when 'q'
+      'questions'
+    when 'a'
+      'a'
+    end
+    unmatched = @results.where("NOT( link like '%/questions/%' OR link like '%/a/%' )")
     @results =  if params[:post_type_include_unmatched]
                   @results.where("link like ?", "%/#{post_type}/%").or(unmatched)
                 else

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,9 +45,7 @@ class SearchController < ApplicationController
                        .paginate(page: params[:page], per_page: per_page)
                        .order('`posts`.`created_at` DESC')
 
-    if params[:option].nil?
-      @results = @results.includes(:reasons).includes(:feedbacks)
-    end
+    @results = @results.includes(:reasons).includes(:feedbacks) if params[:option].nil?
 
     if feedback.present?
       @results = @results.where(feedback => true)
@@ -77,18 +75,18 @@ class SearchController < ApplicationController
       @results = @results.not_autoflagged
     end
 
-
     post_type = case params[:post_type].try(:downcase).try(:[], 0)
-    when 'q'
-      'questions'
-    when 'a'
-      'a'
-    end
+                when 'q'
+                  'questions'
+                when 'a'
+                  'a'
+                end
+
     unmatched = @results.where("NOT( link like '%/questions/%' OR link like '%/a/%' )")
     @results =  if params[:post_type_include_unmatched]
-                  @results.where("link like ?", "%/#{post_type}/%").or(unmatched)
+                  @results.where('link like ?', "%/#{post_type}/%").or(unmatched)
                 else
-                  @results.where("link like ?", "%/#{post_type}/%")
+                  @results.where('link like ?', "%/#{post_type}/%")
                 end
 
     respond_to do |format|

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -82,7 +82,7 @@ class SearchController < ApplicationController
                   'a'
                 end
 
-    unmatched = @results.where("NOT( link like '%/questions/%' OR link like '%/a/%' )")
+    unmatched = @results.where.not("link like '%/questions/%' OR link like '%/a/%'")
     @results =  if params[:post_type_include_unmatched]
                   @results.where('link like ?', "%/#{post_type}/%").or(unmatched)
                 else

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -40,6 +40,11 @@
   </div>
 
   <div class="form-group">
+    <%= label_tag :post_type %>
+    <%= select_tag :post_type, options_for_select(%i[question answer], params[:post_type]), class: "form-control", include_blank: "All" %>
+  </div>
+
+  <div class="form-group">
     <%= label_tag :feedback %>
     <%= select_tag :feedback, options_for_select(["true positive", "false positive", "NAA", "conflicted"], params[:feedback]), class: "form-control", include_blank: "All" %>
   </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -41,6 +41,7 @@
 
   <div class="form-group">
     <%= label_tag :post_type %>
+    <%= check_box_tag :post_type_include_unmatched, 1, params[:post_type_include_unmatched] %> <span class="text-muted">include unmatched</span>
     <%= select_tag :post_type, options_for_select(%i[question answer], params[:post_type]), class: "form-control", include_blank: "All" %>
   </div>
 


### PR DESCRIPTION
Currently, I'm choosing questions/answers based on `/q/` or `/a/` in the URL. That means that the search won't be 100% accurate, so I added a checkbox to either include or exclude unmatched.