### PR TITLE
Search for [^A-Za-z0-9] instead of the unsupported \W

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -73,6 +73,7 @@ class GithubController < ApplicationController
 
     domains.each do |domain|
       domain = domain[0]
+      domain.gsub! '\W', '[^A-Za-z0-9]'
 
       num_tps = Post.where('body LIKE ?', "%#{domain}%").where(is_tp: true).count
       num_fps = Post.where('body LIKE ?', "%#{domain}%").where(is_fp: true).count
@@ -85,7 +86,7 @@ class GithubController < ApplicationController
 
     keywords.each do |keyword|
       keyword = keyword[0]
-      keyword.gsub! '\W', '[ -]'
+      keyword.gsub! '\W', '[^A-Za-z0-9]'
 
       num_tps = Post.where('body LIKE ?', "%#{keyword}%").where(is_tp: true).count
       num_fps = Post.where('body LIKE ?', "%#{keyword}%").where(is_fp: true).count
@@ -98,7 +99,7 @@ class GithubController < ApplicationController
 
     usernames.each do |username|
       username = username[0]
-      username.gsub! '\W', '[ -]'
+      username.gsub! '\W', '[^A-Za-z0-9]'
 
       num_tps = Post.where('username LIKE ?', "%#{username}%").where(is_tp: true).count
       num_fps = Post.where('username LIKE ?', "%#{username}%").where(is_fp: true).count
@@ -111,7 +112,7 @@ class GithubController < ApplicationController
 
     watches.each do |watch|
       watch = watch[0]
-      watch.gsub! '\W', '[ -]'
+      watch.gsub! '\W', '[^A-Za-z0-9]'
 
       num_tps = Post.where('body LIKE ?', "%#{watch}%").where(is_tp: true).count
       num_fps = Post.where('body LIKE ?', "%#{watch}%").where(is_fp: true).count

--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -85,6 +85,7 @@ class GithubController < ApplicationController
 
     keywords.each do |keyword|
       keyword = keyword[0]
+      keyword.gsub! '\W', '[ -]'
 
       num_tps = Post.where('body LIKE ?', "%#{keyword}%").where(is_tp: true).count
       num_fps = Post.where('body LIKE ?', "%#{keyword}%").where(is_fp: true).count
@@ -97,6 +98,7 @@ class GithubController < ApplicationController
 
     usernames.each do |username|
       username = username[0]
+      username.gsub! '\W', '[ -]'
 
       num_tps = Post.where('username LIKE ?', "%#{username}%").where(is_tp: true).count
       num_fps = Post.where('username LIKE ?', "%#{username}%").where(is_fp: true).count
@@ -109,6 +111,7 @@ class GithubController < ApplicationController
 
     watches.each do |watch|
       watch = watch[0]
+      watch.gsub! '\W', '[ -]'
 
       num_tps = Post.where('body LIKE ?', "%#{watch}%").where(is_tp: true).count
       num_fps = Post.where('body LIKE ?', "%#{watch}%").where(is_fp: true).count
@@ -123,7 +126,7 @@ class GithubController < ApplicationController
   end
 
   def get_line(thing, num_tps, num_fps, num_naa)
-    response_text  = "#{thing} has been seen in #{num_tps} true #{'positive'.pluralize(num_tps)}"
+    response_text  = "`#{thing}` has been seen in #{num_tps} true #{'positive'.pluralize(num_tps)}"
     response_text += ", #{num_fps} false #{'positive'.pluralize(num_fps)}"
     response_text += ", and #{num_naa} #{'NAA'.pluralize(num_naa)}."
     response_text + "\n\n"

--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -75,9 +75,9 @@ class GithubController < ApplicationController
       domain = domain[0]
       domain.gsub! '\W', '[^A-Za-z0-9]'
 
-      num_tps = Post.where('body LIKE ?', "%#{domain}%").where(is_tp: true).count
-      num_fps = Post.where('body LIKE ?', "%#{domain}%").where(is_fp: true).count
-      num_naa = Post.where('body LIKE ?', "%#{domain}%").where(is_naa: true).count
+      num_tps = Post.where('body REGEXP ?', "%#{domain}%").where(is_tp: true).count
+      num_fps = Post.where('body REGEXP ?', "%#{domain}%").where(is_fp: true).count
+      num_naa = Post.where('body REGEXP ?', "%#{domain}%").where(is_naa: true).count
 
       response_text += get_line domain, num_tps, num_fps, num_naa
     end
@@ -88,9 +88,9 @@ class GithubController < ApplicationController
       keyword = keyword[0]
       keyword.gsub! '\W', '[^A-Za-z0-9]'
 
-      num_tps = Post.where('body LIKE ?', "%#{keyword}%").where(is_tp: true).count
-      num_fps = Post.where('body LIKE ?', "%#{keyword}%").where(is_fp: true).count
-      num_naa = Post.where('body LIKE ?', "%#{keyword}%").where(is_naa: true).count
+      num_tps = Post.where('body REGEXP ?', "%#{keyword}%").where(is_tp: true).count
+      num_fps = Post.where('body REGEXP ?', "%#{keyword}%").where(is_fp: true).count
+      num_naa = Post.where('body REGEXP ?', "%#{keyword}%").where(is_naa: true).count
 
       response_text += get_line keyword, num_tps, num_fps, num_naa
     end
@@ -101,9 +101,9 @@ class GithubController < ApplicationController
       username = username[0]
       username.gsub! '\W', '[^A-Za-z0-9]'
 
-      num_tps = Post.where('username LIKE ?', "%#{username}%").where(is_tp: true).count
-      num_fps = Post.where('username LIKE ?', "%#{username}%").where(is_fp: true).count
-      num_naa = Post.where('username LIKE ?', "%#{username}%").where(is_naa: true).count
+      num_tps = Post.where('username REGEXP ?', "%#{username}%").where(is_tp: true).count
+      num_fps = Post.where('username REGEXP ?', "%#{username}%").where(is_fp: true).count
+      num_naa = Post.where('username REGEXP ?', "%#{username}%").where(is_naa: true).count
 
       response_text += get_line username, num_tps, num_fps, num_naa
     end
@@ -114,9 +114,9 @@ class GithubController < ApplicationController
       watch = watch[0]
       watch.gsub! '\W', '[^A-Za-z0-9]'
 
-      num_tps = Post.where('body LIKE ?', "%#{watch}%").where(is_tp: true).count
-      num_fps = Post.where('body LIKE ?', "%#{watch}%").where(is_fp: true).count
-      num_naa = Post.where('body LIKE ?', "%#{watch}%").where(is_naa: true).count
+      num_tps = Post.where('body REGEXP ?', "%#{watch}%").where(is_tp: true).count
+      num_fps = Post.where('body REGEXP ?', "%#{watch}%").where(is_fp: true).count
+      num_naa = Post.where('body REGEXP ?', "%#{watch}%").where(is_naa: true).count
 
       response_text += get_line watch, num_tps, num_fps, num_naa
     end


### PR DESCRIPTION
MS has commented a lot of "0 TPs, 0 FPs", in Smokey's PRs. This should fix that wrong search.

P.S. This is my *absolutely first* lines of Ruby code so there may be very stupid syntax or usage errors. Please check them, Thanks.