### PR TITLE
Require review privileges to use regex search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -10,7 +10,7 @@ class SearchController < ApplicationController
     body, body_operation,
     why, why_operation,
     username, username_operation = [:title, :body, :why, :username].map do |s|
-      SearchHelper.parse_search_params(params, s, user_signed_in?)
+      SearchHelper.parse_search_params(params, s, current_user)
     end.flatten
 
     if [title_operation, body_operation, why_operation, username_operation].any?(&:!)

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module SearchHelper
-  def self.parse_search_params(params, symbol, user_signed_in)
+  def self.parse_search_params(params, symbol, user)
     input = params[symbol] || ''
 
     if params[is_regex?(symbol)]
-      operation = if user_signed_in
+      operation = if user != nil and user.can_use_regex_search? 
                     params[is_inverse_regex?(symbol)] ? 'NOT REGEXP' : 'REGEXP'
                   else
                     false

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -5,7 +5,7 @@ module SearchHelper
     input = params[symbol] || ''
 
     if params[is_regex?(symbol)]
-      operation = if user != nil and user.can_use_regex_search? 
+      operation = if !user.nil? && user.can_use_regex_search?
                     params[is_inverse_regex?(symbol)] ? 'NOT REGEXP' : 'REGEXP'
                   else
                     false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -253,6 +253,6 @@ class User < ApplicationRecord
   end
 
   def can_use_regex_search?
-    has_role? :reviewer || moderator_sites.any?
+    (has_role? :reviewer) || moderator_sites.any?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -253,6 +253,6 @@ class User < ApplicationRecord
   end
 
   def can_use_regex_search?
-    has_role? :reviewer or moderator_sites.any?
+    has_role? :reviewer || moderator_sites.any?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -251,4 +251,8 @@ class User < ApplicationRecord
   def has_pinned_role?(role)
     UsersRole.where(user: self, role: Role.find_by(name: role), pinned: true).exists?
   end
+
+  def can_use_regex_search?
+    has_role? :reviewer or moderator_sites.any?
+  end
 end

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -3,7 +3,7 @@
 <%= form_tag (params[:option] == 'graphs' ? search_path(anchor: "graphs") : search_path), method: "get" do |f| %>
   <div class="form-group">
     <%= label_tag :title %>
-    <% if user_signed_in? and current_user.can_use_regex_search? %>
+    <% if current_user&.can_use_regex_search? %>
       <%= check_box_tag :title_is_regex, 1, params[:title_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :title_is_inverse_regex, 1, params[:title_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>
@@ -11,7 +11,7 @@
   </div>
   <div class="form-group">
     <%= label_tag :body %>
-    <% if user_signed_in? and current_user.can_use_regex_search? %>
+    <% if current_user&.can_use_regex_search? %>
       <%= check_box_tag :body_is_regex, 1, params[:body_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :body_is_inverse_regex, 1, params[:body_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>
@@ -19,7 +19,7 @@
   </div>
   <div class="form-group">
     <%= label_tag :username %>
-    <% if user_signed_in? and current_user.can_use_regex_search? %>
+    <% if current_user&.can_use_regex_search? %>
       <%= check_box_tag :username_is_regex, 1, params[:username_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :username_is_inverse_regex, 1, params[:username_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>
@@ -27,7 +27,7 @@
   </div>
   <div class="form-group">
     <%= label_tag :why %>
-    <% if user_signed_in? and current_user.can_use_regex_search? %>
+    <% if current_user&.can_use_regex_search? %>
       <%= check_box_tag :why_is_regex, 1, params[:why_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :why_is_inverse_regex, 1, params[:why_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -3,7 +3,7 @@
 <%= form_tag (params[:option] == 'graphs' ? search_path(anchor: "graphs") : search_path), method: "get" do |f| %>
   <div class="form-group">
     <%= label_tag :title %>
-    <% if user_signed_in? %>
+    <% if user_signed_in? and current_user.can_use_regex_search? %>
       <%= check_box_tag :title_is_regex, 1, params[:title_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :title_is_inverse_regex, 1, params[:title_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>
@@ -11,7 +11,7 @@
   </div>
   <div class="form-group">
     <%= label_tag :body %>
-    <% if user_signed_in? %>
+    <% if user_signed_in? and current_user.can_use_regex_search? %>
       <%= check_box_tag :body_is_regex, 1, params[:body_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :body_is_inverse_regex, 1, params[:body_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>
@@ -19,7 +19,7 @@
   </div>
   <div class="form-group">
     <%= label_tag :username %>
-    <% if user_signed_in? %>
+    <% if user_signed_in? and current_user.can_use_regex_search? %>
       <%= check_box_tag :username_is_regex, 1, params[:username_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :username_is_inverse_regex, 1, params[:username_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>
@@ -27,7 +27,7 @@
   </div>
   <div class="form-group">
     <%= label_tag :why %>
-    <% if user_signed_in? %>
+    <% if user_signed_in? and current_user.can_use_regex_search? %>
       <%= check_box_tag :why_is_regex, 1, params[:why_is_regex] %> <span class="text-muted">regex</span>
       <%= check_box_tag :why_is_inverse_regex, 1, params[:why_is_inverse_regex] %> <span class="text-muted">invert</span>
     <% end %>


### PR DESCRIPTION
As requested by Undo, diamond mods on any site can also use regex search.