### PR TITLE
Add "nuke user" button to user permissions page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,6 +2,7 @@
 
 class AdminController < ApplicationController
   before_action :verify_admin, except: [:user_feedback, :api_feedback, :users, :recently_invalidated, :index]
+  before_action :verify_developer, only: :destroy_user
 
   def index; end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -96,4 +96,9 @@ class AdminController < ApplicationController
 
     render plain: 'success', status: :accepted
   end
+
+  def destroy_user
+    User.find(params[:user_id]).destroy
+    render plain: 'success', status: :accepted
+  end
 end

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -5,16 +5,16 @@ import { onLoad } from './util';
 const debug = createDebug('ms:admin');
 
 onLoad(() => {
-  var nukeUserConfirmed = false;
+  let nukeUserConfirmed = false;
 
   $('a.nuke-user-link').click(function (e) {
     e.preventDefault();
 
     const $this = $(this);
     if (!nukeUserConfirmed) {
-      nukeUserConfirmed = window.confirm("Are you sure?  This will permanently destroy '" + $this.data('username') + "' and all associated records.  " + 
-                                         "Note that you will not be prompted for confirmation to nuke another user until you refresh the page.");
-      if (!nukeUserConfirmed) return;
+      nukeUserConfirmed = window.confirm('Are you sure?  This will permanently destroy \'' + $this.data('username') + '\' and all associated records.  ' +
+                                         'Note that you will not be prompted for confirmation to nuke another user until you refresh the page.');
+      if (!nukeUserConfirmed) { return; }
     }
     $.ajax({
       type: 'delete',

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -14,7 +14,9 @@ onLoad(() => {
     if (!nukeUserConfirmed) {
       nukeUserConfirmed = window.confirm('Are you sure?  This will permanently destroy \'' + $this.data('username') + '\' and all associated records.  ' +
                                          'Note that you will not be prompted for confirmation to nuke another user until you refresh the page.');
-      if (!nukeUserConfirmed) { return; }
+      if (!nukeUserConfirmed) { 
+          return; 
+      }
     }
     $.ajax({
       type: 'delete',

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -5,6 +5,26 @@ import { onLoad } from './util';
 const debug = createDebug('ms:admin');
 
 onLoad(() => {
+  var nukeUserConfirmed = false;
+
+  $('a.nuke-user-link').click(function (e) {
+    e.preventDefault();
+
+    const $this = $(this);
+    if (!nukeUserConfirmed) {
+      nukeUserConfirmed = window.confirm("Are you sure?  This will permanently destroy '" + $this.data('username') + "' and all associated records.  " + 
+                                         "Note that you will not be prompted for confirmation to nuke another user until you refresh the page.");
+      if (!nukeUserConfirmed) return;
+    }
+    $.ajax({
+      type: 'delete',
+      url: '/admin/permissions/' + $this.data('user-id'),
+      success() {
+        $this.closest('tr').remove();
+      }
+    });
+  });
+
   $('input.permissions-checkbox').change(function () {
     const $this = $(this);
     $this.disabled = true;

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -14,8 +14,8 @@ onLoad(() => {
     if (!nukeUserConfirmed) {
       nukeUserConfirmed = window.confirm('Are you sure?  This will permanently destroy \'' + $this.data('username') + '\' and all associated records.  ' +
                                          'Note that you will not be prompted for confirmation to nuke another user until you refresh the page.');
-      if (!nukeUserConfirmed) { 
-          return; 
+      if (!nukeUserConfirmed) {
+        return;
       }
     }
     $.ajax({

--- a/app/views/admin/permissions.html.erb
+++ b/app/views/admin/permissions.html.erb
@@ -13,7 +13,9 @@
     <% @roles.map {|r| r.to_s.humanize.titlecase }.each do |role_name| %>
       <th><%= role_name %></th>
     <% end %>
-    <th></th>
+    <% if current_user&.has_role?(:developer) %>
+     <th></th>
+    <% end %>
   <tr>
 
   <% @users.each do |user| %>
@@ -34,7 +36,9 @@
           </label>
         </td>
       <% end %>
-      <td><%= link_to "Nuke", 'javascript:void(0);', class: 'text-danger nuke-user-link', data: { :user_id => user.id, :username => user.username } %></td>
+      <% if current_user&.has_role?(:developer) %>
+        <td><%= link_to "Nuke", 'javascript:void(0);', class: 'text-danger nuke-user-link', data: { :user_id => user.id, :username => user.username } %></td>
+      <% end %>
     </tr>
   <% end %>
 </table>

--- a/app/views/admin/permissions.html.erb
+++ b/app/views/admin/permissions.html.erb
@@ -13,6 +13,7 @@
     <% @roles.map {|r| r.to_s.humanize.titlecase }.each do |role_name| %>
       <th><%= role_name %></th>
     <% end %>
+    <th></th>
   <tr>
 
   <% @users.each do |user| %>
@@ -33,6 +34,7 @@
           </label>
         </td>
       <% end %>
+      <td><%= link_to "Nuke", 'javascript:void(0);', class: 'text-danger nuke-user-link', data: { :user_id => user.id, :username => user.username } %></td>
     </tr>
   <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
   delete 'admin/destroy_ignored/:id', to: 'admin#destroy_ignored'
   get 'admin/permissions'
   put 'admin/permissions/update', to: 'admin#update_permissions'
+  delete 'admin/permissions/:user_id', to: 'admin#destroy_user'
 
   get 'admin/invalidate_tokens', to: 'authentication#invalidate_tokens'
   post 'admin/invalidate_tokens', to: 'authentication#send_invalidations'


### PR DESCRIPTION
This PR adds a "nuke" button to the right of the checkboxes on the user permissions page, to allow admins to easily destroy users.  The button uses AJAX and removes the row from the table on success.  It asks for confirmation the first time it's used, but after you've nuked one user it won't ask for confirmation until you refresh the page.

The code probably has room for improvement, since I don't do frontend very much.