### PR TITLE
Add link to 'site settings' page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,6 +83,7 @@
                   <%= nav_link AdminController, label: 'User Permissions', action: :permissions %>
                   <%= nav_link APIKeysController, label: 'API Keys' %>
                   <%= nav_link AdminController, label: 'Admin Report Queue', action: :flagged %>
+                  <%= nav_link SiteSettingsController, label: 'Website Configuration' %>
                 <% end %>
                 <% if current_user.has_role? :developer %>
                   <%#


### PR DESCRIPTION
I've named it 'Website configuration' rather than 'Site settings' to try and make it clearer that we're talking about metasmoke, not individual SE sites. I would write 'metasmoke settings', but then capitalisation would be messy (officially, it's m, but M looks better in the dropdown).