### PR TITLE
Remove feedback from post comment (partially)

### DIFF
--- a/app/models/post_comment.rb
+++ b/app/models/post_comment.rb
@@ -18,7 +18,14 @@ class PostComment < ApplicationRecord
   belongs_to :post
   belongs_to :user
 
+  before_create :remove_feedbacks
+
   def self.scrubber
     CommentScrubber.new
+  end
+
+  def remove_feedbacks
+    _feedback_type, comment = text.scan(/(fp|tp|why)\W*(.*)/).flatten
+    self.text = comment.to_s
   end
 end

--- a/app/models/post_comment.rb
+++ b/app/models/post_comment.rb
@@ -25,7 +25,7 @@ class PostComment < ApplicationRecord
   end
 
   def remove_feedbacks
-    _feedback_type, comment = text.scan(/(fp|tp|why)\W*(.*)/i).flatten
+    _feedback_type, comment = text.scan(/(fp|tp|why)?\W*(.*)/i).flatten
     self.text = comment.to_s
   end
 end

--- a/app/models/post_comment.rb
+++ b/app/models/post_comment.rb
@@ -25,7 +25,7 @@ class PostComment < ApplicationRecord
   end
 
   def remove_feedbacks
-    _feedback_type, comment = text.scan(/(fp|tp|why)\W*(.*)/).flatten
+    _feedback_type, comment = text.scan(/(fp|tp|why)\W*(.*)/i).flatten
     self.text = comment.to_s
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
     encryption_key = AppConfig['stack_exchange']['token_aes_key']
     begin
       return AESCrypt.decrypt(encrypted_api_token, encryption_key, salt, iv)
-    rescue OpenSSL::Cipher::CipherError
+    rescue OpenSSL::Cipher::CipherError, ArgumentError
       # Since dev environments don't have the proper keys to perform
       # decryption on a prod data dump, we allow this error in dev
       return encrypted_api_token if Rails.env.development? || Rails.env.test?

--- a/app/views/post_comments/_comment.html.erb
+++ b/app/views/post_comments/_comment.html.erb
@@ -20,17 +20,3 @@
     <%= raw(sanitize(PostCommentsController.renderer.render(comment.text), scrubber: PostComment.scrubber)) %>
   </div>
 </div>
-
-<!--
-
-background-color: rgba(255,255,255,0.7);
-
-padding: 1px;
-
-border-radius: 3px;
-
-box-shadow: 0px 0px 2px 2px rgba(255,255,255,0.7);
-
-font-weight: bold;
-
--->

--- a/app/views/post_comments/_comment.html.erb
+++ b/app/views/post_comments/_comment.html.erb
@@ -1,6 +1,9 @@
 <div class="panel panel-primary post-comment" data-cid="<%= comment.id %>">
   <div class="panel-heading">
     <strong><%= comment.user.username %></strong>
+    <% if feedback %>
+      <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="text-white">(<%= element_symbol_for_feedback(feedback).html_safe %>)</span>
+    <% end %>
     <span title="<%= comment.created_at %>"><%= time_ago_in_words comment.created_at %> ago</span>
     <% if current_user == comment.user || current_user&.has_role?(:admin) %>
       <span class="comment-control">
@@ -17,3 +20,17 @@
     <%= raw(sanitize(PostCommentsController.renderer.render(comment.text), scrubber: PostComment.scrubber)) %>
   </div>
 </div>
+
+<!--
+
+background-color: rgba(255,255,255,0.7);
+
+padding: 1px;
+
+border-radius: 3px;
+
+box-shadow: 0px 0px 2px 2px rgba(255,255,255,0.7);
+
+font-weight: bold;
+
+-->

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -157,7 +157,7 @@
 <% end %>
 
 <% @post.comments.each do |c| %>
-  <%= render 'post_comments/comment', comment: c %>
+  <%= render 'post_comments/comment', comment: c, feedback: Feedback.find_by(post: @post, user: c.user) %>
 <% end %>
 
 <p><a href="#" class="new-comment"><span class="glyphicon glyphicon-plus"></span> Add a comment</a></p>


### PR DESCRIPTION
On creation of a post comment, commands (only "tp", "fp", and "why") are removed from the start of a comment. Instead of that stuff leaving comments, the users feedback is now in the header of a comment. If this is desireable, accept this PR, if not, feel free to close it. Either way, close #425.