### PR TITLE
Fix minor bug when viewing past reviews

### DIFF
--- a/app/controllers/review_queues_controller.rb
+++ b/app/controllers/review_queues_controller.rb
@@ -28,8 +28,8 @@ class ReviewQueuesController < ApplicationController
 
     @item = ReviewItem.find params[:item_id]
 
-    # Prevent the same item from being reviewed twice by the same user.
-    if (@item.completed && ReviewResult.exists?(item: @item)) ||
+    # Prevent the same item from being reviewed after it is completed, or twice by the same user.
+    if (@item.completed && ReviewResult.where(item: item).where.not(result: "skip").exists?) ||
        ReviewResult.where(user: current_user, item: @item).where.not(result: 'skip').exists?
 
       render json: { status: 'duplicate' }, status: 409

--- a/app/views/review_queues/_responses.html.erb
+++ b/app/views/review_queues/_responses.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-body">
-    <% if (item.completed and ReviewResult.exists?(item: item)) or
+    <% if (item.completed and ReviewResult.where(item: item).where.not(result: "skip").exists?) or
         ReviewResult.where(user: current_user, item: item).where.not(result: "skip").exists? %>
     <h5>
       <% if item.completed %>
@@ -29,5 +29,5 @@
       <%= link_to 'Skip', submit_review_path(name: queue.name, item_id: item.id, response: 'skip'), class: 'btn btn-primary review-submit-link',
                   method: :post, remote: true %>
     <% end %>
-  </div>
+  </di
 </div>


### PR DESCRIPTION
In order to prevent completed reviews from being reviewed again, I blocked reviews if the review item was completed and at least one review result existed.  However, I failed to ensure that the existing review result was not a skip.  This meant that adding a domain tag to a domain others have skipped made the item unreviewable.

This PR fixes the bug by changing the check to ensure at least one non-skip review exists.