### PR TITLE
Use *? wildcards and escape %_ when searching keywords

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -21,7 +21,7 @@ module SearchHelper
       regex_support.each { |k, v| input = input.gsub(k, v) }
     else
       operation = 'LIKE'
-      input = '%' + input + '%'
+      input = '%' + ActiveRecord::Base.sanitize_sql_like(input) + '%'
     end
 
     [input, operation]


### PR DESCRIPTION
As of now when you searching something like `100%` or `to_string`, the `%_` will be treated as SQL wildcards. This patch escapes `%_` and enable the use of `*?` as wildcards. Escaped `\*` and `\?` will match literal `*?`s.