### PR TITLE
Prevent errors when a non-capturing group is used in a regex search.

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -16,7 +16,8 @@ module SearchHelper
         '\s' => '[\r\n\t\f\v ]',
         '\S' => '[^\r\n\t\f\v ]',
         '\d' => '[0-9]',
-        '\D' => '[^0-9]'
+        '\D' => '[^0-9]',
+        '(?:' => '('
       }
       regex_support.each { |k, v| input = input.gsub(k, v) }
     else


### PR DESCRIPTION
metasmoke's regex search produces an error when the syntax is used for a non-capturing group (e.g. `(?:foo)`). User's may desire to use non-capturing groups for regexes being tested for use in SmokeDetector (doing so provides some slight/moderate performance improvement vs. a capture group). There would be no difference to metasmoke search results between non-capturing groups and capturing groups, if non-capturing groups were actually used/possible. It's more convenient for users to be able to use non-capturing group syntax without producing an error.

This change will result in the syntax `(?:foo)` being treated exactly like (i.e. substituted to be) just a normal capture group, `(foo)`.