### PR TITLE
Resolve eslint errors causing ci/circleci to fail on flag_settings.js

### DIFF
--- a/app/javascript/flag_settings.js
+++ b/app/javascript/flag_settings.js
@@ -1,47 +1,47 @@
-import {route} from './util';
+import { route } from './util';
 
 route('/flagging/settings/sites', () => {
-    $('.unsaved-changes').hide();
+  $('.unsaved-changes').hide();
 
-    $('.site-search').on('change', (ev) => {
-        const search = $(ev.target).val();
-        $('tbody tr').each((i, e) => {
-            const sid = $(e).data('sid');
-            const siteData = window.flagging_settings[sid];
-            if (siteData.name.indexOf(search) === -1 && siteData.domain.indexOf(search) === -1) {
-                $(e).hide();
-            }
-            else {
-                $(e).show();
-            }
-        });
+  $('.site-search').on('change', ev => {
+    const search = $(ev.target).val();
+    $('tbody tr').each((i, e) => {
+      const sid = $(e).data('sid');
+      const siteData = window.flagging_settings[sid];
+      if (siteData.name.indexOf(search) === -1 && siteData.domain.indexOf(search) === -1) {
+        $(e).hide();
+      }
+      else {
+        $(e).show();
+      }
     });
+  });
 
-    $('input[type=checkbox]').on('change', (ev) => {
-        $('.unsaved-changes').show();
+  $('input[type=checkbox]').on('change', ev => {
+    $('.unsaved-changes').show();
 
-        const sid = $(ev.target).parents('tr').data('sid').toString();
-        window.flagging_settings[sid].flags_enabled = $(ev.target).is(':checked');
-        window.flagging_settings[sid].changed = true;
+    const sid = $(ev.target).parents('tr').data('sid').toString();
+    window.flagging_settings[sid].flags_enabled = $(ev.target).is(':checked');
+    window.flagging_settings[sid].changed = true;
+  });
+
+  $('input[type=number]').on('keyup', ev => {
+    $('.unsaved-changes').show();
+
+    const sid = $(ev.target).parents('tr').data('sid').toString();
+    window.flagging_settings[sid].max_flags = parseInt($(ev.target).val(), 10);
+    window.flagging_settings[sid].changed = true;
+  });
+
+  $('.save-changes').on('click', async ev => {
+    ev.preventDefault();
+
+    await fetch('/flagging/settings/sites', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data: window.flagging_settings })
     });
-
-    $('input[type=number]').on('keyup', (ev) => {
-        $('.unsaved-changes').show();
-
-        const sid = $(ev.target).parents('tr').data('sid').toString();
-        window.flagging_settings[sid].max_flags = parseInt($(ev.target).val(), 10);
-        window.flagging_settings[sid].changed = true;
-    });
-
-    $('.save-changes').on('click', async (ev) => {
-        ev.preventDefault();
-
-        await fetch('/flagging/settings/sites', {
-            method: 'POST',
-            credentials: 'include',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({data: window.flagging_settings})
-        });
-        $('.unsaved-changes').fadeOut(200);
-    });
+    $('.unsaved-changes').fadeOut(200);
+  });
 });


### PR DESCRIPTION
This was done by issuing `xo --fix flag_settings.js`
The changes were that changing from Windows linebreaks to Unix and various spacing issues, including using 2 space indenting instead of 4, some spaces after/before `{` and `}`, along with not using `()` to enclose a single argument for `=>`.