### PR TITLE
Flag spam on localized sites

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,7 +208,7 @@ class User < ApplicationRecord
     end
 
     spam_flag_option = flag_options.select do |fo|
-      ['spam', 'contenido no deseado', 'スパム', 'спам'].include? fo['title']
+      ['spam', 'contenido no deseado', 'スパム', 'спам'].any? { |itnl_title| fo['title'].include? itnl_title }
     end.first
 
     return false, 'Spam flag option not present' if spam_flag_option.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,9 @@ class User < ApplicationRecord
       end
     end
 
-    spam_flag_option = flag_options.select { |fo| fo['title'] == 'spam' }.first
+    spam_flag_option = flag_options.select do |fo|
+      ['spam', 'contenido no deseado', 'スパム', 'спам'].include? fo['title']
+    end.first
 
     return false, 'Spam flag option not present' if spam_flag_option.blank?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,7 +208,7 @@ class User < ApplicationRecord
     end
 
     spam_flag_option = flag_options.select do |fo|
-      ['spam', 'contenido no deseado', 'スパム', 'спам'].any? { |itnl_title| fo['title'].include? itnl_title }
+      ['spam', 'contenido no deseado', 'スパム', 'спам'].include? fo['title']
     end.first
 
     return false, 'Spam flag option not present' if spam_flag_option.blank?


### PR DESCRIPTION
We've been doing autoflagging very well on English sites and pt.SO, but it seems like MS has never flagged a single post on localized sites (except pt.SO). It turns out to be SE API responding with localized flag text which fails the selector test:

```ruby
fo['title'] == 'spam'
```

Maybe we tell MS to recognize localized flag text?