### PR TITLE
Fix user not unblacklisted when fp sent

### DIFF
--- a/app/models/stack_exchange_user.rb
+++ b/app/models/stack_exchange_user.rb
@@ -25,7 +25,8 @@ class StackExchangeUser < ApplicationRecord
 
   def unblacklist_user
     ActionCable.server.broadcast 'smokedetector_messages', unblacklist: {
-      uid: user_id.to_s
+      uid: user_id.to_s,
+      site: URI.parse(site.site_url).host
     }
   end
 end


### PR DESCRIPTION
The previous PR (#355) attempts to unblacklist the user, but apparently the data sent is incorrect so the user is not unblacklisted. Now this PR attempts to fix that bug.

Fixes #346