### PR TITLE
Add OpenSearch support

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
 
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= favicon_link_tag       '/favicon.ico' %>
+  <link rel="search" type="application/opensearchdescription+xml" title="metasmoke"
+        href="https://metasmoke.erwaysoftware.com/opensearch.xml">
 
   <%= stylesheet_link_tag "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" %>
   <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.1/css/bootstrap-select.min.css" %>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>metasmoke</ShortName>
+  <Description>Searches the content of all post bodies in metasmoke.</Description>
+  <Url type="text/html" template="https://metasmoke.erwaysoftware.com/search?body={searchTerms}"/>
+  <Image height="32" width="32" type="image/vnd.microsoft.icon">https://metasmoke.erwaysoftware.com/favicon.ico</Image>
+  <LongName>metasmoke post bodies search</LongName>
+  <SyndicationRight>limited</SyndicationRight>
+  <moz:SearchForm>https://metasmoke.erwaysoftware.com/search</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Add an OpenSearch description document according to the [specification](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md). 

I'm not sure how well other browsers support this, but this addition will allow metasmoke to be added as a search engine in Firefox. This allows me to search for any keywords directly from my browser like this:

![ms opensearch](https://user-images.githubusercontent.com/4848802/44299286-94f20e00-a2e2-11e8-9783-6f4b2888b3c7.PNG)
