### PR TITLE
Remove regex search substitutions not needed with MariaDB.

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -69,7 +69,7 @@ class GithubController < ApplicationController
     domains = text.scan(/<!-- METASMOKE-BLACKLIST-WEBSITE (.*?) -->/)
 
     domains.each do |domain|
-      domain = SearchHelper.regex_support domain[0]
+      domain = domain[0]
 
       num_tps = Post.where('body REGEXP ?', domain).where(is_tp: true).count
       num_fps = Post.where('body REGEXP ?', domain).where(is_fp: true).count
@@ -81,7 +81,7 @@ class GithubController < ApplicationController
     keywords = text.scan(/<!-- METASMOKE-BLACKLIST-KEYWORD (.*?) -->/)
 
     keywords.each do |keyword|
-      keyword = SearchHelper.regex_support keyword[0]
+      keyword = keyword[0]
 
       num_tps = Post.where('body REGEXP ?', keyword).where(is_tp: true).count
       num_fps = Post.where('body REGEXP ?', keyword).where(is_fp: true).count
@@ -93,7 +93,7 @@ class GithubController < ApplicationController
     usernames = text.scan(/<!-- METASMOKE-BLACKLIST-USERNAME (.*?) -->/)
 
     usernames.each do |username|
-      username = SearchHelper.regex_support username[0]
+      username = username[0]
 
       num_tps = Post.where('username REGEXP ?', username).where(is_tp: true).count
       num_fps = Post.where('username REGEXP ?', username).where(is_fp: true).count
@@ -105,7 +105,7 @@ class GithubController < ApplicationController
     watches = text.scan(/<!-- METASMOKE-BLACKLIST-WATCH_KEYWORD (.*?) -->/)
 
     watches.each do |watch|
-      watch = SearchHelper.regex_support watch[0]
+      watch = watch[0]
 
       num_tps = Post.where('body REGEXP ?', watch).where(is_tp: true).count
       num_fps = Post.where('body REGEXP ?', watch).where(is_fp: true).count

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -10,7 +10,6 @@ module SearchHelper
                   else
                     false
                   end
-      input = regex_support input
     else
       operation = 'LIKE'
       input = '%' + ActiveRecord::Base.sanitize_sql_like(input) + '%'
@@ -25,21 +24,5 @@ module SearchHelper
 
   def self.is_inverse_regex?(symbol) # rubocop:disable Style/PredicateName
     (symbol.to_s + '_is_inverse_regex').to_sym
-  end
-
-  def self.regex_support(text)
-    {
-      '\w' => '[a-zA-Z0-9_]',
-      '\W' => '[^a-zA-Z0-9_]',
-      '\s' => '[\r\n\t\f\v ]',
-      '\S' => '[^\r\n\t\f\v ]',
-      '\d' => '[0-9]',
-      '\D' => '[^0-9]',
-      '\b' => '(^|[[:<:]]|[[:>:]]|$)',
-      '(?:' => '('
-    }.each do |k, v|
-      text = text.gsub k, v
-    end
-    text
   end
 end


### PR DESCRIPTION
MariaDB >= 10.0.5 uses PCRE for it's regular expressions (we're using 10.3.9). Thus, all of the character classes, assertion, and non-capturing group which we were substituting here are now natively supported, in a syntax similar to what is used for SD. With native support, having these substitutions in place is detrimental, as it prevents some valid uses (e.g. `[\W_]`, or `[\w-]`).

Whoever is reviewing this should certainly double check these changes. I don't know the language, so just did what appeared consistent with the existing syntax and what the code looked like prior to changes being added to implement these substitutions.