### PR TITLE
Register TPU regardless of success state of spam flag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -189,7 +189,7 @@ class PostsController < ApplicationController
                             user_id: current_user.id,
                             post_id: @post.id)
 
-    feedback.save || flash[:danger] = 'Unable to save feedback. Ping Undo.'
+    flash[:danger] = 'Unable to save feedback. Ping Undo.' unless feedback.save
 
     if current_user.api_token.blank?
       flash[:warning] = 'You must be write-authenticated to cast a spam flag.'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -185,6 +185,14 @@ class PostsController < ApplicationController
   end
 
   def cast_spam_flag
+    feedback = Feedback.new(feedback_type: 'tpu-',
+                            user_id: current_user.id,
+                            post_id: @post.id)
+
+    unless feedback.save
+      flash[:danger] = 'Unable to save feedback. Ping Undo.'
+    end
+
     if current_user.api_token.blank?
       flash[:warning] = 'You must be write-authenticated to cast a spam flag.'
       redirect_to(authentication_status_path) && return
@@ -203,13 +211,6 @@ class PostsController < ApplicationController
     if result
       flash[:success] = 'Spam flag cast successfully.'
 
-      feedback = Feedback.new(feedback_type: 'tpu-',
-                              user_id: current_user.id,
-                              post_id: @post.id)
-
-      unless feedback.save
-        flash[:danger] = 'Unable to save feedback. Ping Undo.'
-      end
     else
       flash[:danger] = "Spam flag not cast: #{message}"
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -189,9 +189,7 @@ class PostsController < ApplicationController
                             user_id: current_user.id,
                             post_id: @post.id)
 
-    unless feedback.save
-      flash[:danger] = 'Unable to save feedback. Ping Undo.'
-    end
+    feedback.save || flash[:danger] = 'Unable to save feedback. Ping Undo.'
 
     if current_user.api_token.blank?
       flash[:warning] = 'You must be write-authenticated to cast a spam flag.'


### PR DESCRIPTION
When someone clicks "Spam flag", it's sure they want to give a TPU feedback as well. The current code does not if the spam flag is not cast successfully. Moving relevant code to before flag attempt solves this.