### PR TITLE
Remove `.git/info/attributes` before merging Smokey PR

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -252,13 +252,6 @@ class GithubController < ApplicationController
         Dir.chdir('SmokeDetector') do
           system 'git config user.name metasmoke'
           system 'git', 'config', 'user.email', AppConfig['github']['username']
-
-          File.write '.git/info/attributes', <<~END
-            bad_keywords.txt -text merge=union
-            blacklisted_usernames.txt -text merge=union
-            blacklisted_websites.txt -text merge=union
-            watched_keywords.txt -text merge=union
-          END
         end
       end
 


### PR DESCRIPTION
Independent of this, I have already noticed the use of `.gitattributes` and created it in Smokey's repo, so MS doesn't need to have a separate one. It'll work well

<https://github.com/Charcoal-SE/SmokeDetector/commit/3f5b3574e84ec1f793e14a8a7cfa6cbf8f2ec78c>
<https://github.com/Charcoal-SE/SmokeDetector/commit/9da4f89a0da9d0eb047bb549662ed1e6ae83653f>