### PR TITLE
Fixed search icon href

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -152,7 +152,7 @@
               <% end %>
             <% end %>
             <% if controller.class == DashboardController %>
-              <li class="search-icon hidden-xs"><a class="glyphicon glyphicon-search" href=#><span class="sr-only">Search</span></a></li>
+              <li class="search-icon hidden-xs"><a class="glyphicon glyphicon-search" href="/search"><span class="sr-only">Search</span></a></li>
             <% end %>
           </ul>
         </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
The `href` for the search icon previously pointed to `#` instead of `/search`. I corrected that, although it could be removed altogether as it's redundant to the search nav item and is only present on the dashboard.