### PR TITLE
Clean up after the token migration beta

### DIFF
--- a/app/views/custom_registrations/edit.html.erb
+++ b/app/views/custom_registrations/edit.html.erb
@@ -81,30 +81,6 @@
       </div>
     </div>
 
-    <div class="panel panel-default">
-      <div class="panel-body">
-        <h3>Token storage beta</h3>
-        <% if !current_user.token_migrated %>
-          <div class="alert alert-info" role="alert">
-            <p>
-              We're currently beta testing a new way to cast autoflags. The new system will be safer in that even someone with direct server access does
-              not have your access_token (the thing which lets others act on your behalf). Currently, this safer token vault is on an AWS Lambda and
-              will store tokens in AWS DynamoDB under thesecretmaster's account. He will have full read access to your tokens, and when this system is
-              migrated to Undo's account, Undo will also have access. By clicking this button, you consent to both thesecretmaster and Undo having
-              access to your account's API access tokens, which allows them to perform actions under your account.
-            </p><br/>
-
-            <% state = Rails.cache.fetch("token_migration_state/#{current_user.id}", expires_in: 30.minutes) { SecureRandom.hex(10) } %>
-            <%= link_to 'Help test the new autoflagging system!', "#{AppConfig['token_store']['host']}/auth?state=#{state}", class: 'btn btn-info' %>
-          </div>
-        <% else %>
-          <div class="alert alert-info" role="alert">
-            You're signed up for our token beta thing! Ping Undo in Charcoal HQ if you'd like to be removed.
-          </div>
-        <% end %>
-      </div>
-    </div>
-
     <div class="panel panel-danger">
       <div class="panel-body">
         <h3 class="text-danger">Cancel my account</h3>

--- a/db/migrate/20181221203016_drop_encrypted_api_token_from_users.rb
+++ b/db/migrate/20181221203016_drop_encrypted_api_token_from_users.rb
@@ -1,0 +1,5 @@
+class DropEncryptedAPITokenFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :encrypted_api_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_17_200352) do
+ActiveRecord::Schema.define(version: 2018_12_21_203016) do
 
   create_table "abuse_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.bigint "user_id"
@@ -547,7 +547,6 @@ ActiveRecord::Schema.define(version: 2018_12_17_200352) do
     t.integer "stackoverflow_chat_id"
     t.integer "stack_exchange_account_id"
     t.boolean "flags_enabled", default: false
-    t.string "encrypted_api_token"
     t.string "two_factor_token"
     t.boolean "enabled_2fa"
     t.binary "salt"


### PR DESCRIPTION
I think I did most of this, but do we want to do more, like renaming the `token_migrated` column?