### PR TITLE
Issue #318 fix. code_admin out in favor of blacklist_manager verbage.

### DIFF
--- a/app/channels/status_channel.rb
+++ b/app/channels/status_channel.rb
@@ -2,8 +2,8 @@
 
 class StatusChannel < ApplicationCable::Channel
   def subscribed
-    if current_user&.has_role?(:code_admin)
-      stream_from 'status_code_admin'
+    if current_user&.has_role?(:blacklist_manager)
+      stream_from 'status_blacklist_manager'
     else
       stream_from 'status'
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -163,7 +163,7 @@ class APIController < ApplicationController
   # Read routes: Users
 
   def users_with_code_privs
-    chat_ids = User.code_admins.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
+    chat_ids = User.blacklist_manager.pluck(:stackexchange_chat_id, :stackoverflow_chat_id, :meta_stackexchange_chat_id)
 
     items = {}
     %w[stackexchange_chat_ids stackoverflow_chat_ids meta_stackexchange_chat_ids].each_with_index do |name, index|

--- a/app/controllers/smoke_detectors_controller.rb
+++ b/app/controllers/smoke_detectors_controller.rb
@@ -3,7 +3,7 @@
 class SmokeDetectorsController < ApplicationController
   before_action :authenticate_user!, except: %i[audits check_token]
   before_action :verify_admin, except: %i[audits force_failover force_pull mine token_regen new create check_token]
-  before_action :verify_code_admin, only: %i[force_failover force_pull]
+  before_action :verify_blacklist_manager, only: %i[force_failover force_pull]
   before_action :verify_smoke_detector_runner, only: %i[mine token_regen new create]
   before_action :set_smoke_detector, except: %i[audits mine new create check_token]
 

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -24,7 +24,7 @@ class StatusController < ApplicationController
 
     Thread.new do
       ActionCable.server.broadcast 'status', status_channel_data
-      ActionCable.server.broadcast 'status_code_admin', status_channel_data.merge(failover_link: failover_link)
+      ActionCable.server.broadcast 'status_blacklist_manager', status_channel_data.merge(failover_link: failover_link)
       ActionCable.server.broadcast 'topbar', last_ping: @smoke_detector.last_ping.to_f
       ActionCable.server.broadcast 'smokey_pings', smokey: @smoke_detector.as_json
     end

--- a/app/jobs/conflicting_feedback_job.rb
+++ b/app/jobs/conflicting_feedback_job.rb
@@ -37,7 +37,7 @@ class ConflictingFeedbackJob < ApplicationJob
       # User precedences. Higher numbers mean a user possessing this role will override a user possessing a lower role.
       # Everyone gets flagger, so that's worth a whole nothing; developer likewise because you can be a developer without knowing anything about
       # feedback (and all of our current developers have other high-precedence roles as well).
-      roles = { flagger: 0, reviewer: 1, core: 2, code_admin: 3, smoke_detector_runner: 3, admin: 4, developer: 0 }
+      roles = { flagger: 0, reviewer: 1, core: 2, blacklist_manager: 3, smoke_detector_runner: 3, admin: 4, developer: 0 }
 
       # One-liner beauty (or hell, depending how you look at it). First get a list of all feedbacks and the maximum precedence of the user who
       # created it. Secondly, take that list and uniq-ify it by summing all precedences for the same feedback type.

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -16,6 +16,6 @@ class Role < ApplicationRecord
   scopify
 
   def self.names
-    %i[reviewer flagger core smoke_detector_runner code_admin admin developer]
+    %i[reviewer flagger core smoke_detector_runner blacklist_manager admin developer]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,8 +109,8 @@ class User < ApplicationRecord
     end
   end
 
-  def self.code_admins
-    Role.where(name: :code_admin).first.users
+  def self.blacklist_manager
+    Role.where(name: :blacklist_manager).first.users
   end
 
   def remember_me

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -30,7 +30,7 @@
                 data: {confirm: "This will be logged, and cannot be undone. Sure?"}, method: :delete %>
         <% end %>
       </td>
-      <% if current_user&.has_role?(:code_admin) %>
+      <% if current_user&.has_role?(:blacklist_manager) %>
         <% if sd.last_ping > 3.minutes.ago %>
           <td class="status-failover-cell">
             <% if sd.is_standby %>

--- a/db/migrate/20160530154118_add_is_code_admin_to_users.rb
+++ b/db/migrate/20160530154118_add_is_code_admin_to_users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class AddIsCodeAdminToUsers < ActiveRecord::Migration[5.0]
+class AddIsBlacklistManagerToUsers < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :is_code_admin, :boolean, default: false
+    add_column :users, :is_blacklist_manager, :boolean, default: false
   end
 end

--- a/db/migrate/20161012170148_migrate_to_roles_based_permissions.rb
+++ b/db/migrate/20161012170148_migrate_to_roles_based_permissions.rb
@@ -5,7 +5,7 @@ class MigrateToRolesBasedPermissions < ActiveRecord::Migration[5.0]
     User.all.each do |u|
       u.add_role :reviewer if u.is_approved
       u.add_role :admin if u.is_admin
-      u.add_role :code_admin if u.is_code_admin
+      u.add_role :blacklist_manager if u.is_blacklist_manager
     end
   end
 

--- a/db/migrate/20161012180740_remove_legacy_permissions_attributes.rb
+++ b/db/migrate/20161012180740_remove_legacy_permissions_attributes.rb
@@ -4,6 +4,6 @@ class RemoveLegacyPermissionsAttributes < ActiveRecord::Migration[5.0]
   def change
     remove_column :users, :is_approved
     remove_column :users, :is_admin
-    remove_column :users, :is_code_admin
+    remove_column :users, :is_blacklist_manager
   end
 end

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -24,8 +24,8 @@ admin:
       name: Etc/UTC
     time: *2
 
-code_admin:
-  name: code_admin
+blacklist_manager:
+  name: blacklist_manager
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: &1 2016-10-12 17:06:30.000000000 Z
     zone: !ruby/object:ActiveSupport::TimeZone

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -26,7 +26,7 @@ system_user:
     zone: !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *5
-  roles: reviewer, code_admin
+  roles: reviewer, blacklist_manager
   id: -1
 
 
@@ -97,8 +97,8 @@ admin_user:
     time: *5
   roles: reviewer, admin
 
-code_admin_user:
-  email: code_admin@user.com
+blacklist_manager_user:
+  email: blacklist_manager@user.com
   encrypted_password: "abcdefghjklmnopqrstuvwxyz3"
   remember_created_at:
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -117,7 +117,7 @@ code_admin_user:
     zone: !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *5
-  roles: reviewer, code_admin
+  roles: reviewer, blacklist_manager
 
 two_factor_confirming:
   email: two_factor@user.com


### PR DESCRIPTION
First open source contribution! Hopefully its close(ish) to being correct. I renamed every occurrence of code_admin to blacklist_manager. Including all method calls and variables I could find. Thanks for your consideration and guidance. 