### PR TITLE
Adjust authentication visibility

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,7 +143,7 @@ class UsersController < ApplicationController
                        query: { account_id: current_user.stack_exchange_account_id, state: state })
     Rails.logger.info res
     if params[:state] == state && JSON.parse(res.body)['token_exists'] && current_user.update(flags_enabled: true)
-      flash[:success] = 'Your registration was completed sucessfully!'
+      flash[:success] = 'Your registration was completed successfully!'
     elsif params[:error].present?
       flash[:danger] = "Got an error: #{params[:error]}: #{params[:error_description]}"
     else

--- a/app/views/authentication/status.html.erb
+++ b/app/views/authentication/status.html.erb
@@ -4,7 +4,8 @@
 <% if current_user.stack_exchange_account_id.nil? %>
   <%= link_to "Authenticate", identify_auth_url, class: "btn btn-success" %>
 <% else %>
-  <p class="text-muted">(you have already authenticated)</p>
+  <h4><strong>You have already authenticated. You do not need to do so again.</strong></h4>
+  <p>However, you can authenticate again (e.g. if you are experiencing problems).</p>
   <% if current_user.has_role? :flagger %>
     <div class="alert alert-danger">
       <p>


### PR DESCRIPTION
We've had various people be confused about if they have successfully authenticated with SE for flagging. This changes the visibility of the notice that tells people they have already authenticated.

New:

[![adjusted already authenticated notice](https://i.stack.imgur.com/Qrkd0.png)](https://i.stack.imgur.com/Qrkd0.png)