### PR TITLE
Rework text on autoflagging preferences page.

### DIFF
--- a/app/views/user_site_settings/index.html.erb
+++ b/app/views/user_site_settings/index.html.erb
@@ -1,21 +1,29 @@
 <h3><%= title "Autoflagging Preferences" %></h3>
-<p>These are the preferences you've set for autoflagging. You can choose only certain sites to flag on by associating
-  your preferences with only those sites.</p>
-
+<h4>Getting started</h4>
+<p>
+    If you're trying to get started with autoflags for the first time, you'll need to:
+</p>
+<ul>
+  <li>authorize metasmoke for write access to your Stack Exchange account (see "Clifford the Big Red Button" below)</li>
+  <li>set up your preferences (below), which govern how many of your flags metasmoke can use per-site. You must set at least one preference.</li>
+  <li><%= link_to "set up your autoflagging conditions", url_for(controller: :flag_conditions, action: :index) %>, which govern how certain you want metasmoke to be a post is spam before using your account to flag it. You must set at least one flagging condition.</li>
+</ul>
+<h4>Authenticating metasmoke with your Stack Exchange account</h4>
 <div class="panel panel-danger">
   <div class="panel-heading">
     <h3 class="panel-title">Clifford the Big Red Button</h3>
   </div>
   <div class="panel-body">
     <p>
-      <strong class="text-danger">Warning:</strong> for all the joking about, this is serious. By ticking this box, you are explicitly consenting to
-      your Stack Exchange account being used to cast flags automatically based on data collected by SmokeDetector. While we believe this has a high
-      rate of accuracy and have designed the system to reflect this, flags cast using your account are your responsibility, and many invalid flags
-      can in some cases result in your SE account being suspended. Only tick the box if you are happy with this responsibility.
+      <strong class="text-danger">Warning:</strong> for all the joking about, this is serious. By authenticating metasmoke for write access to your Stack Exchange account, you
+      are explicitly consenting to your Stack Exchange account being used to cast flags automatically based on data collected by SmokeDetector. While we believe this has a high
+      rate of accuracy and have designed the system to reflect this, <i>flags cast using your account are your responsibility</i>, and having many invalid flags can, in some cases,
+      result in your SE account being suspended, or being temporarily banned from flagging. Only authenticate metasmoke for write access if you accept this responsibility.
     </p>
     <hr/>
     <% if current_user.api_token.nil? %>
-      <p class="text-info">You need to authenticate for write access first; <%= link_to "you can do that here", url_for(controller: :authentication, action: :status) %>.</p>
+      <p class="text-info">If you have not already done so, you need to first authenticate metasmoke for write access with Stack Exchange; <strong><%= link_to "you can do that here", url_for(controller: :authentication, action: :status) %></strong>.</p>
+      <p class="text-info">The above link will also show you if metasmoke thinks it's already write-authorized and allow you to re-authorize, if you've removed the authorization in your Stack Exchange preferences (metasmoke won't know you've removed authorization until it tries to flag).</p>
     <% else %>
       <input id="red-button" name="red-button" type="checkbox" <%= "checked" if current_user.flags_enabled %> <%= "disabled" if (FlagSetting["registration_enabled"] == "0" || !current_user.has_role?(:flagger)) and not current_user.flags_enabled %> />
       <label for="red-button">Use my account to cast flags automatically</label>
@@ -23,13 +31,11 @@
         <p class="text-muted">Registration is currently disabled.</p>
       <% end %>
     <% end %>
-    <hr/>
-    If you're trying to get started with autoflags for the first time, you'll also need to set up your preferences (which govern how many of your
-    flags we can use per-site) and conditions (which govern how certain you want us to be of a post before using your account to flag it). Links to
-    these are at the bottom of this page.
   </div>
 </div>
 
+<h4>Preferences: maximum number of flags metasmoke will use</h4>
+<p>Each preference below sets the maximum number of your flags metasmoke will use on a site or group of sites. In order for metasmoke to use your account for autoflagging, you need to have at least one such preference set.</p>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -56,9 +62,8 @@
 </table>
 
 <% if FlagSetting['registration_enabled'] == '1' %>
+  <%= link_to "Add new maximum flags per site preference", url_for(controller: :user_site_settings, action: :new) %><br/>
   <p><em>Don't want to set this up yourself? <%= link_to "There's a wizard for that.", url_for(controller: :flag_conditions, action: :one_click_setup) %></em></p>
-  <%= link_to "Set up preferences", url_for(controller: :user_site_settings, action: :new) %><br/>
-  <%= link_to "Set up conditions", url_for(controller: :flag_conditions, action: :index) %>
 <% else %>
   <p class="text-muted"><em>Registration for autoflagging is currently closed.</em></p>
 <% end %>


### PR DESCRIPTION
We've had users be confused as to the process of setting up their metasmoke account for autoflagging.

This should change the [Autoflagging Preferences page](https://metasmoke.erwaysoftware.com/flagging/preferences) to the following:

[![image of proposed preferences page](https://i.stack.imgur.com/2UySE.png)](https://i.stack.imgur.com/2UySE.png)

However, in making these edits, I noticed that at least part of the confusion is that portions of the code in this file are just not working. There is supposed to be different content shown if the user is write-authorized. However, that does not happen at this point. This may be the result of the changes made to move flagging to its own server, but I'm vaguely remembering that it wasn't working before that.

Some of the changes I made to the "Warning" paragraph in the "Clifford the Big Red Button" block are based on the checkbox no longer being displayed. I changed the wording to no longer talk about a checkbox, as that was confusing when I was reading it. I only belatedly realized that it was talking about what was supposed to be displayed when the user was write authorized.

Looking at this page and the [authentication status page](https://metasmoke.erwaysoftware.com/authentication/status), it's not clear to me what criteria should be used to actually indicate that MS definitely is, in fact, write authenticated. It also appeared that the authentication being removed by the user in their SE preferences is not checked for (i.e. there isn't an active check that the token we hold is valid). The logic, if it was working, also doesn't appear to cover well a situation where the user needs MS to try to re-authorize, even though MS thinks it is authorized (e.g. user removed the authorization on SE).

I feel that reworking the text and page organization as I have done here is beneficial both now, and with more work, when the check for being write authorized is working again, this is not a complete solution. To an extent, it feels like a band-aid, but one that will help reduce user confusion.

Also, note: I don't have an MS test environment, so these changes are untested.

