### PR TITLE
Prevent time_ago_in_words evaluation if feedback.created_at isn't present

### DIFF
--- a/app/views/feedbacks/clear.html.erb
+++ b/app/views/feedbacks/clear.html.erb
@@ -29,7 +29,7 @@
       <tr class="<%= feedback.is_invalidated? ? "danger" : "" %>">
         <td class="<%= element_class_for_feedback feedback %>"><%= feedback.feedback_type %></td>
         <td><%= feedback.user_name || ("#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" if feedback.user.present?) %></td>
-        <td><span title="<%= feedback.created_at %>"><%= time_ago_in_words(feedback.created_at) %> ago</span></td>
+        <td><span title="<%= feedback.created_at %>"><%= feedback.created_at.present? ? time_ago_in_words(feedback.created_at) + " ago" : "no data" %></span></td>
         <td><%= link_to("delete", delete_feedback_path(feedback), method: :delete) if (!feedback.is_invalidated? && (current_user.has_role?(:admin) || feedback.user_id == current_user.id)) %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
Please be sure to review this, as I'm really not familiar with the syntax or best practices.

Resolves #634 