### PR TITLE
Fix flag settings dashboard: Remove an extraneous comma

### DIFF
--- a/app/views/flag_settings/dashboard.html.erb
+++ b/app/views/flag_settings/dashboard.html.erb
@@ -101,7 +101,7 @@
   <h3>Admin</h3>
   <ul>
     <li><%= link_to "All conditions", url_for(controller: :flag_conditions, action: :full_list) %></li>
-    <li><%= link_to "Per-site flag limits", url_for(controller: :flag_settings, action: :site_settings), %></li>
+    <li><%= link_to "Per-site flag limits", url_for(controller: :flag_settings, action: :site_settings) %></li>
     <li><%= link_to "Invalidate API tokens", url_for(controller: :authentication, action: :invalidate_tokens), class: "text-danger" %></li>
   </ul>
 


### PR DESCRIPTION
My previous PR, #656, had an extraneous comma that causes the [flag settings dashboard](https://metasmoke.erwaysoftware.com/flagging) to be broken.