### PR TITLE
rubocop: simple syntax changes

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -93,9 +93,8 @@ class AuthenticationController < ApplicationController
     Thread.new do
       User.where(id: params[:users]).each do |user|
         HTTParty.post("#{AppConfig['token_store']['host']}/invalidate_tokens",
-          body: { account_id: user.stack_exchange_account_id }.to_json,
-          headers: { 'X-API-Key': AppConfig['token_store']['key'], 'Content-Type' => 'application/json' }
-        )
+                      body: { account_id: user.stack_exchange_account_id }.to_json,
+                      headers: { 'X-API-Key': AppConfig['token_store']['key'], 'Content-Type' => 'application/json' })
         user.update(write_authenticated: false)
       end
     end

--- a/app/controllers/reasons_controller.rb
+++ b/app/controllers/reasons_controller.rb
@@ -2,7 +2,7 @@
 
 class ReasonsController < ApplicationController
   before_action :verify_core, only: [:update_description]
-  
+
   def show
     @reason = Reason.find(params[:id])
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -254,7 +254,7 @@ class Post < ApplicationRecord
 
   def parse_domains
     hosts = part_to_extract_from_domains.map do |x|
-      x = CGI::unescape x
+      x = CGI.unescape(x)
       begin
         URI.parse(x).hostname.gsub(/www\./, '').downcase
       rescue


### PR DESCRIPTION
This fixes some rubocop errors. These ones are adjusting whitespace and changing `CGI::unescape x` to `CGI.unescape(x)`.

In combination with the other PRs I'm submitting, it should result in CI passing. CI won't be passing in its entirety without all of the PRs being merged. This is in multiple PRs because you may not want parts of it, so only take the ones, or just the commits, which are desired.