### PR TITLE
Review pages: title and history for all review types

### DIFF
--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -34,20 +34,21 @@ route(/\/review\/[\w-]+\/?\d*$/i, async () => {
     $('.review-item-container').html(html);
 
     try {
-      if (window.location.pathname.indexOf('/review/posts') === 0) {
+      const pathname = window.location.pathname;
+      const isHistory = pathname.endsWith('/history');
+      const historyText = isHistory ? '' : 'history for ';
+      const reviewTypeText = pathname.split('/')[2].split('-').map(word => word[0].toUpperCase() + word.slice(1)).join(' ');
+      if (!isHistory && pathname.indexOf('/review/posts') === 0) {
         const postTitle = $('h4')[0].firstChild.textContent.trim();
         const postID = $('h4 a').attr('href').replace(/^\D*(\d+)/, '$1');
         const relativeUrl = $('.review-submit-link').first().attr('href').replace(/\?.*/, '');
         const reviewID = relativeUrl.match(/\d+/)[0];
-        const title = `Posts Review ${reviewID}: post ID ${postID}: ${postTitle} - metasmoke`;
+        const title = `Review Posts ${reviewID}: post ID ${postID}: ${postTitle} - metasmoke`;
         document.title = title;
         history.pushState({}, title, relativeUrl);
       }
-      else if (window.location.pathname.indexOf('/review/untagged-domains') === 0) {
-        document.title = 'Review Untagged Domains - metasmoke';
-      }
-      else if (window.location.pathname.indexOf('/review/admin-flags') === 0) {
-        document.title = 'Review Admin Flags - metasmoke';
+      else {
+        document.title = `Review ${reviewTypeText} ${historyText}- metasmoke`;
       }
     }
     catch (err) {

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -33,13 +33,26 @@ route(/\/review\/[\w-]+\/?\d*$/i, async () => {
     const html = await response.text();
     $('.review-item-container').html(html);
 
-    const postTitle = $('h4')[0].firstChild.textContent.trim();
-    const postID = $('h4 a').attr('href').replace(/^\D*(\d+)/, '$1');
-    const relativeUrl = $('.review-submit-link').first().attr('href').replace(/\?.*/, '');
-    const reviewID = relativeUrl.match(/\d+/)[0];
-    const title = `Review ${reviewID}: post ID ${postID}: ${postTitle} - metasmoke`;
-    document.title = title;
-    history.pushState({}, title, relativeUrl);
+    try {
+      if (window.location.pathname.indexOf('/review/posts') === 0) {
+        const postTitle = $('h4')[0].firstChild.textContent.trim();
+        const postID = $('h4 a').attr('href').replace(/^\D*(\d+)/, '$1');
+        const relativeUrl = $('.review-submit-link').first().attr('href').replace(/\?.*/, '');
+        const reviewID = relativeUrl.match(/\d+/)[0];
+        const title = `Posts Review ${reviewID}: post ID ${postID}: ${postTitle} - metasmoke`;
+        document.title = title;
+        history.pushState({}, title, relativeUrl);
+      }
+      else if (window.location.pathname.indexOf('/review/untagged-domains') === 0) {
+        document.title = 'Review Untagged Domains - metasmoke';
+      }
+      else if (window.location.pathname.indexOf('/review/admin-flags') === 0) {
+        document.title = 'Review Admin Flags - metasmoke';
+      }
+    }
+    catch (err) {
+      console.error(err); // eslint-disable-line no-console
+    }
 
     installSelectpickers();
   };

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -36,19 +36,35 @@ route(/\/review\/[\w-]+\/?\d*$/i, async () => {
     try {
       const pathname = window.location.pathname;
       const isHistory = pathname.endsWith('/history');
-      const historyText = isHistory ? '' : 'history for ';
+      const historyText = isHistory ? 'history for ' : '';
       const reviewTypeText = pathname.split('/')[2].split('-').map(word => word[0].toUpperCase() + word.slice(1)).join(' ');
-      if (!isHistory && pathname.indexOf('/review/posts') === 0) {
-        const postTitle = $('h4')[0].firstChild.textContent.trim();
-        const postID = $('h4 a').attr('href').replace(/^\D*(\d+)/, '$1');
-        const relativeUrl = $('.review-submit-link').first().attr('href').replace(/\?.*/, '');
-        const reviewID = relativeUrl.match(/\d+/)[0];
-        const title = `Review Posts ${reviewID}: post ID ${postID}: ${postTitle} - metasmoke`;
-        document.title = title;
-        history.pushState({}, title, relativeUrl);
+      const submitLink = $('.review-submit-link');
+      const relativeUrl = (submitLink.length ? submitLink.first().attr('href') : pathname).replace(/\?.*/, '');
+      const reviewID = (relativeUrl.match(/\d+/) || [''])[0];
+      const reviewIDText = reviewID ? `: Review #${reviewID}` : '';
+      let title = document.title;
+      let extraText = '';
+      if (!isHistory) {
+        if (pathname.indexOf('/review/posts') === 0) {
+          const titleEl = $('h4:not(.modal-title)');
+          // If the titleEl doesn't exist, then all reviews are done.
+          if (titleEl.length > 0) {
+            const postTitle = $('h4')[0].firstChild.textContent.trim();
+            const postID = $('h4 a').attr('href').replace(/^\D*(\d+)/, '$1');
+            extraText = `: post ID ${postID}: ${postTitle}`;
+          }
+        }
+        else if (pathname.indexOf('/review/untagged-domains') === 0) {
+          extraText = `: ${$('h3').first().text()}`;
+        }
+      }
+      title = `Review ${historyText}${reviewTypeText}${reviewIDText}${extraText} - metasmoke`;
+      document.title = title;
+      if (relativeUrl === pathname) {
+        history.replaceState({}, title, relativeUrl);
       }
       else {
-        document.title = `Review ${reviewTypeText} ${historyText}- metasmoke`;
+        history.pushState({}, title, relativeUrl);
       }
     }
     catch (err) {


### PR DESCRIPTION
This should fix #670.

In addition, it will also set the `document.title` and keep browser history for reviews in the other two review types, along with setting the `document.title` for the three types of review history pages.