### PR TITLE
nokogiri (>= 1.10.4) (security alert)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       addressable (~> 2.3)
     loofah (2.2.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.10.4)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)


### PR DESCRIPTION
Change nokogiri to >=1.10.4, due to the security alert [here](https://github.com/Charcoal-SE/metasmoke/network/alert/Gemfile.lock/nokogiri/open).