### PR TITLE
Filter revisions for revision_number

### DIFF
--- a/app/models/concerns/post_concerns/autoflagging.rb
+++ b/app/models/concerns/post_concerns/autoflagging.rb
@@ -195,7 +195,7 @@ module PostConcerns::Autoflagging
       post ||= self
       return if post.site.blank?
       Rails.logger.warn "[autoflagging] #{id}: site was present"
-      params = "key=#{AppConfig['stack_exchange']['key']}&site=#{post.site.site_domain}&filter=!mggE4ZSiE7"
+      params = "key=#{AppConfig['stack_exchange']['key']}&site=#{post.site.site_domain}&filter=!mggkQI*4m9"
 
       url = "https://api.stackexchange.com/2.2/posts/#{post.stack_id}/revisions?#{params}"
       revision_list = JSON.parse(Net::HTTP.get_response(URI.parse(url)).body)['items']

--- a/app/models/concerns/post_concerns/autoflagging.rb
+++ b/app/models/concerns/post_concerns/autoflagging.rb
@@ -199,6 +199,8 @@ module PostConcerns::Autoflagging
 
       url = "https://api.stackexchange.com/2.2/posts/#{post.stack_id}/revisions?#{params}"
       revision_list = JSON.parse(Net::HTTP.get_response(URI.parse(url)).body)['items']
+      # Filter out items which are not actual post revisions
+      revision_list = revision_list.select { |revision| revision.revision_number.present? }
       Rails.logger.warn "[autoflagging] #{id}: queried SE: #{revision_list&.count}"
 
       update(revision_count: revision_list.count)


### PR DESCRIPTION
This should resolve #574 & #696.

This should leave the `revision_list` containing only items from the [SE API `revisions` data](https://api.stackexchange.com/docs/types/revision) which are actual post revisions (indicated by the presence of `revision_number`). As a result, the `revision_count` should contain a count of only the actual revisions, rather than also including a count of the changes in the post's state (e.g. close, open, locked, community wiki, etc.).

Contrary to the "Question Closed" example in the above linked SE API `revisions` data, revisions in the list which are not actual edits don't contain a `revision_number` property. To verify this, you can look at the following two examples:

* [Example CW answer](https://stackoverflow.com/a/32836072/3773011), [SE API revisions data with the filter used in the code](https://api.stackexchange.com/docs/revisions-by-ids#ids=32836072&filter=!mggkQI*4m9&site=stackoverflow&run=true): Shows the post being CW when created, the initial revision, deletion, and undeletion. Only the initial revision has a `revision_number`. ([SE API revisions data with default filter](https://api.stackexchange.com/docs/revisions-by-ids#ids=32836072&filter=default&site=stackoverflow&run=true))
* [Example question](https://stackoverflow.com/q/448673/3773011). [SE API revisions data with the filter used in the code](https://api.stackexchange.com/docs/revisions-by-ids#ids=448673&filter=!mggkQI*4m9&site=stackoverflow&run=true): Shows 9 revisions, protection, unprotection, closed, post notice added, and locked. Only the actual revisions have a `revision_number`. ([SE API revisions data with default filter](https://api.stackexchange.com/docs/revisions-by-ids#ids=448673&filter=default&site=stackoverflow&run=true))


This touches on the autoflagging code, so should be reviewed.