### PR TITLE
Change User Info page to be admin rather than developer

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@
 
 class UsersController < ApplicationController
   before_action :authenticate_user!, except: [:missing_privileges]
-  before_action :verify_developer, only: %i[show refresh_ids send_password_reset update_mod_sites]
+  before_action :verify_admin, only: %i[show refresh_ids send_password_reset]
+  before_action :verify_developer, only: %i[update_mod_sites]
   before_action :set_user, only: %i[show refresh_ids send_password_reset update_mod_sites]
 
   def username; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,8 @@
 
 class UsersController < ApplicationController
   before_action :authenticate_user!, except: [:missing_privileges]
-  before_action :verify_admin, only: %i[show refresh_ids send_password_reset]
-  before_action :verify_developer, only: %i[update_mod_sites]
+  before_action :verify_admin, only: %i[show send_password_reset]
+  before_action :verify_developer, only: %i[refresh_ids update_mod_sites]
   before_action :set_user, only: %i[show refresh_ids send_password_reset update_mod_sites]
 
   def username; end

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -37,13 +37,18 @@
           <td><%= user.roles.map(&:name).map{|n| n.humanize.downcase}.to_sentence.capitalize %></td>
         <% end %>
         <td><%= link_to 'Feedback', admin_user_feedback_path(user_id: user.id) %></td>
-        <% if current_user&.has_role?(:developer) %>
+        <% if current_user&.has_role?(:admin) %>
+          <td><%= link_to 'Flagging', user_overview_path(user: user.id) %></td>
           <td>
-            <%= link_to 'Developer', dev_user_path(user) %>
-            (<%= link_to 'Logs', redis_log_by_user_path(user) %>)
+            <%= link_to 'User Info', dev_user_path(user) %>
+            <% if current_user&.has_role?(:developer) %>
+              (<%= link_to 'Logs', redis_log_by_user_path(user) %>)
+            <% end %>
           </td>
-          <td><%= link_to 'Impersonate', impersonate_path(user), method: :post, class: 'text-warning' %></td>
-          <td><%= link_to 'Nuke', 'javascript:void(0);', class: 'text-danger nuke-user-link', data: { user_id: user.id, username: user.username } %></td>
+          <% if current_user&.has_role?(:developer) %>
+            <td><%= link_to 'Impersonate', impersonate_path(user), method: :post, class: 'text-warning' %></td>
+            <td><%= link_to 'Nuke', 'javascript:void(0);', class: 'text-danger nuke-user-link', data: { user_id: user.id, username: user.username } %></td>
+          <% end %>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,9 +24,11 @@
           <%= @user.stackoverflow_chat_id.present? ? @user.stackoverflow_chat_id : 'null' %>]<span style="white-space:pre;">  </span># <%= @user.username %><br/>
           <strong>rooms.yml:</strong><span style="white-space:pre;">      - </span><%= @user.stack_exchange_account_id.present? ? @user.stack_exchange_account_id : 'null' %> # <%= @user.username %><br/>
         </p>
-        <p>
-          <%= link_to 'Refresh chat IDs', update_user_chat_ids_path(@user), method: :post, class: 'btn btn-info' %>
-        </p>
+        <% if current_user&.has_role?(:developer) %>
+          <p>
+            <%= link_to 'Refresh chat IDs', update_user_chat_ids_path(@user), method: :post, class: 'btn btn-info' %>
+          </p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,7 +38,7 @@
       <div class="panel-body">
         <p>
           <strong>Enabled:</strong> <%= @user.flags_enabled? ? 'Yes' : 'No' %><br/>
-          <%= link_to 'User Overview', user_overview_path(user: @user.id) %>
+          <%= link_to 'User\'s Flagging', user_overview_path(user: @user.id) %>
         </p>
       </div>
     </div>
@@ -77,9 +77,12 @@
         <% else %>
           <p><em>User is not a moderator.</em></p>
         <% end %>
-        <p>
-          <%= link_to 'Refresh mod sites', update_mod_sites_path(@user), method: :post, class: 'btn btn-info' %>
-        </p>
+        <% if current_user&.has_role?(:developer) %>
+          <p>
+            <!-- This route updates mod sites for all users, so is developer only. -->
+            <%= link_to 'Refresh mod sites', update_mod_sites_path(@user), method: :post, class: 'btn btn-info' %>
+          </p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,7 +38,7 @@
       <div class="panel-body">
         <p>
           <strong>Enabled:</strong> <%= @user.flags_enabled? ? 'Yes' : 'No' %><br/>
-          <%= link_to 'User\'s Flagging', user_overview_path(user: @user.id) %>
+          <%= link_to 'Flagger Overview', user_overview_path(user: @user.id) %>
         </p>
       </div>
     </div>


### PR DESCRIPTION
The intent of this change is to make the page which summarizes user information ([example](https://metasmoke.erwaysoftware.com/users/71)) accessible to admins, not just developers. It appeared to me that the information contained in the page is user-centric, which feels more appropriate for an administrator role, rather than restricting it to developers. Most of the information is publicly available (either through the MS API, or on SE), or is directly relevant to the individual user.

The button that causes all the moderator sites to be re-determined was left as developer only, as it affects all users and is quite expensive from a SE API point of view.

As usual, these changes include a significant amount of educated guesses on my part as how all this works, so should be reviewed from that POV.

It should also be reviewed from the POV of: "should this actually be changed". This change reflects my opinion/understanding of the separation between admin and developer, which may not be consistent with what was intended.
