### PR TITLE
Make footer full-width and don't leave bottom

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,16 @@
  *= require_self
  */
 
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.initial-content {
+  flex: 1 0 auto;
+}
+
 .footer {
   width: 100%;
   background-color: #fafafa;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -183,7 +183,7 @@
     <% end %>
     </div><!-- /.container-fluid -->
   </nav>
-  <div class="col-md-offset-1 col-md-10">
+  <div class="initial-content col-md-offset-1 col-md-10">
     <% Rack::MiniProfiler.step('Rendering: layouts/application/announcements') do %>
     <div class="alert alert-warning" id="metasmoke-deployed-banner" style="display: none" role="alert">
       This page has been updated. <a href="" data-turbolinks="false">Refresh</a> to get the latest version.
@@ -205,13 +205,15 @@
     <% end %>
     <% end %>
     <%= yield %>
-    <div class="footer">
+  </div>
+  <footer class="footer">
+    <div class="col-md-offset-1 col-md-10">
       <p class="text-muted">
         We are <a href="//charcoal-se.org/">Charcoal</a> (not <a href="//stackexchange.com/">Stack Exchange</a>). We make <a href="//github.com/Charcoal-SE">nice things</a>.<br/>
         <a href="//chat.stackexchange.com/rooms/11540/charcoal-hq">chat</a> • <a href="//charcoal-se.org/security">security</a> • <a href="mailto:smokey@charcoal-se.org">contact</a><br/>
         <span class="small">Post content sourced from the <a href="http://stackexchange.com">Stack Exchange Network</a>.</span>
       </p>
     </div>
-  </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
Two changes here:

- Move footer out of the container for main content so it can have a full-width background
- Use flexbox to make the footer stay at bottom for short content.

Preview:

- Before:

  ![image](https://user-images.githubusercontent.com/7273074/81320998-9bcb4080-90c4-11ea-9788-fb179f1d466b.png)

- After:

  ![image](https://user-images.githubusercontent.com/7273074/81320870-71798300-90c4-11ea-824c-d234c73b46f7.png)

Generally should work on any browser that supports CSS flexbox.

CSS learned from [mmistakes/minimal-mistakes](https://github.com/mmistakes/minimal-mistakes/blob/master/_sass/minimal-mistakes/_page.scss#L22-L36)