### PR TITLE
Include a link in the "PR opened" messages

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -57,7 +57,8 @@ class GithubController < ApplicationController
 
     pull_request = params[:pull_request]
 
-    SmokeDetector.send_message_to_charcoal("PR##{pull_request[:number]} (\"#{pull_request[:title]}\") opened by #{pull_request[:user][:login]}")
+    SmokeDetector.send_message_to_charcoal("[PR##{pull_request[:number]}](#{pull_request[:url]}) " +
+                                           "(\"#{pull_request[:title]}\") opened by #{pull_request[:user][:login]}")
 
     unless pull_request[:user][:login] == 'SmokeDetector'
       render(text: 'Not from SmokeDetector. Uninterested.') && return


### PR DESCRIPTION
I can't think of a reason not to, and it saves a few clicks.