### PR TITLE
In chat, have a PR URL which is intended for humans

### DIFF
--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -57,8 +57,9 @@ class GithubController < ApplicationController
 
     pull_request = params[:pull_request]
 
-    SmokeDetector.send_message_to_charcoal("[PR##{pull_request[:number]}](#{pull_request[:url]}) " +
-                                           "(\"#{pull_request[:title]}\") opened by #{pull_request[:user][:login]}")
+    SmokeDetector.send_message_to_charcoal("[PR##{pull_request[:number]}]"\
+                                           "(https://github.com/Charcoal-SE/SmokeDetector/pull/#{pull_request[:number]})"\
+                                           " (\"#{pull_request[:title]}\") opened by #{pull_request[:user][:login]}")
 
     unless pull_request[:user][:login] == 'SmokeDetector'
       render(text: 'Not from SmokeDetector. Uninterested.') && return


### PR DESCRIPTION
The URL here is what's displayed in chat. We're wanting the URL a user can click on to go to the PR. `pull_request[:url]` is the URL for the PR in the GitHub API, not the user accessible URL. This PR just constructs the URL based on the PR number.