### PR TITLE
search_controller.rb: unregistered users may not use LIKE

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,7 +47,7 @@ class SearchController < ApplicationController
       end
     end
 
-    if ['LIKE', 'NOT LIKE'].include?(body_operation) && user_signed_in? && params[:body_is_like] != '1' && body.present?
+    if ['LIKE', 'NOT LIKE'].include?(body_operation) && params[:body_is_like] != '1' && body.present?
       # If the operation would be LIKE, hijack it and use our fulltext index for a search instead.
       # UNLESS... params[:body_is_like] is set, in which case the user has explicitly specified a LIKE query.
       @results = @results.match_search(body, with_search_score: false, posts: :body)


### PR DESCRIPTION
In the original implementation, unregistered users' search operations on body are not redirected to fulltext index.