### PR TITLE
Fix mysterious "dig: command not found" in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
         MYSQL_DATABASE: 'metasmoke_test'
 
     steps:
-    - run: sudo apt-get install apt-utils redis-server
+    - run: sudo apt-get install dnsutils apt-utils redis-server
     - run: sudo service redis-server start
     - checkout
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/7273074/85362649-90878380-b551-11ea-81e2-b55ace6867fe.png)
