### PR TITLE
blockquote font-size: inherit, it was too big

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -16,7 +16,7 @@ pre.post-body-pre-block {
 }
 
 blockquote {
-	font-size: inherit;
+  font-size: inherit;
 }
 
 .post-body {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -15,6 +15,10 @@ pre.post-body-pre-block {
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
+blockquote {
+	font-size: inherit;
+}
+
 .post-body {
   clear: both;
 }


### PR DESCRIPTION
The default value of `17.5px` is set by Bootstrap so we can't modify it (have to override).

Problem:

> ![image](https://user-images.githubusercontent.com/7273074/86506545-cacf0b80-be02-11ea-954e-2c6cfd94d67e.png)

Solution:

> ![image](https://user-images.githubusercontent.com/7273074/86506554-da4e5480-be02-11ea-84fe-49a2c2bcba13.png)
