### PR TITLE
In autoflagging, calculate the post weight outside condition validation loops

### DIFF
--- a/app/models/concerns/post_concerns/autoflagging.rb
+++ b/app/models/concerns/post_concerns/autoflagging.rb
@@ -19,8 +19,11 @@ module PostConcerns::Autoflagging
       begin
         conditions = post.site.flag_conditions.where(flags_enabled: true)
         available_user_ids = {}
+        weight = post.reasons.pluck(:weight).reduce(:+)
+        poster_rep = post.stack_exchange_user.reputation
+        reasons_count = post.reasons.count
         conditions.each do |condition|
-          if condition.validate!(post)
+          if condition.validate_weight_rep_reason_count!(weight, poster_rep, reasons_count)
             available_user_ids[condition.user.id] = condition
           end
         end
@@ -167,8 +170,11 @@ module PostConcerns::Autoflagging
     def eligible_flaggers
       conditions = site.flag_conditions.where(flags_enabled: true)
       available_user_ids = {}
+      weight = reasons.pluck(:weight).reduce(:+)
+      poster_rep = stack_exchange_user.reputation
+      reasons_count = reasons.count
       conditions.each do |condition|
-        if condition.validate!(self)
+        if condition.validate_weight_rep_reason_count!(weight, poster_rep, reasons_count)
           available_user_ids[condition.user_id] = condition
         end
       end

--- a/app/models/flag_condition.rb
+++ b/app/models/flag_condition.rb
@@ -65,10 +65,14 @@ class FlagCondition < ApplicationRecord
     accuracy
   end
 
-  def validate!(post)
-    post.reasons.pluck(:weight).reduce(:+) >= min_weight &&
-      post.stack_exchange_user.reputation <= max_poster_rep &&
-      post.reasons.count >= min_reason_count
+  def validate_weight_rep_reason_count!(weight, poster_rep, reason_count)
+    weight >= min_weight && poster_rep <= max_poster_rep && reason_count >= min_reason_count
+  end
+
+  def validate_post!(post)
+    validate_weight_rep_reason_count!(post.reasons.pluck(:weight).reduce(:+),
+                                      post.stack_exchange_user.reputation,
+                                      post.reasons.count)
   end
 
   def posts

--- a/app/models/flag_condition.rb
+++ b/app/models/flag_condition.rb
@@ -69,7 +69,7 @@ class FlagCondition < ApplicationRecord
     weight >= min_weight && poster_rep <= max_poster_rep && reason_count >= min_reason_count
   end
 
-  def validate_post!(post)
+  def validate!(post)
     validate_weight_rep_reason_count!(post.reasons.pluck(:weight).reduce(:+),
                                       post.stack_exchange_user.reputation,
                                       post.reasons.count)


### PR DESCRIPTION
As [discussed briefly in chat](https://chat.stackexchange.com/transcript/message/54849478#54849478), this moves the calculation of the post's weight to outside the loops which determine the users with flagging conditions which match the post.

As usual, my experience with Ruby is minimal, so please look for stupid/naive mistakes.

#### Why make this change:

Basically, `condition.validate!(post)` calls `post.reasons.pluck(:weight).reduce(:+)` every time `condition.validate!(post)` is called (i.e. each iteration through the loop). That's the way that function needs to handle it in order to validate an arbitrary post. That's good and modular OOP. However, it's inefficient when wanting to validate the same post against multiple flagging conditions.

In the loops this PR changes, we're looping through all enabled flagging conditions to validate each condition against the same post. We know we're testing the same post every loop iteration, just against a different flagging condition. So, the value returned by `post.reasons.pluck(:weight).reduce(:+)` will be the same through every iteration of the loop, but the call to `condition.validate!(post)` still results in a database access in each loop iteration to get a value which won't change.

There are, currently, 450+ existing flagging conditions.  Of those, 330+ are enabled. So, the existing code makes 330+ redundant database accesses to get the post's weight when traversing this loop, which is done for every post reported to MS. The purpose of this PR is to pull that database access out of the loop, so it's only done once, prior to the loop. The value resulting from that database access is then used in each loop iteration.

This PR should save us a few to several hundred database accesses for each post reported to MS.