### PR TITLE
Fix some image too large with "img { max-width: 100%; }"

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -19,6 +19,10 @@ blockquote {
   font-size: inherit;
 }
 
+img {
+  max-width: 100%;
+}
+
 .post-body {
   clear: both;
 }


### PR DESCRIPTION
Fixes posts like [251257](https://metasmoke.erwaysoftware.com/post/251257).