### PR TITLE
Added the ability to remove user added domains

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -28,7 +28,7 @@ class Post < ApplicationRecord
   has_and_belongs_to_many :reasons
   has_and_belongs_to_many :post_tags, class_name: 'DomainTag'
   has_many :post_spam_domains
-  has_and_belongs_to_many :spam_domains
+  has_many :spam_domains, through: :post_spam_domains
   has_many :feedbacks, dependent: :destroy
   has_many :deletion_logs, dependent: :destroy
   has_many :flag_logs, dependent: :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,6 +27,7 @@ class Post < ApplicationRecord
   belongs_to :smoke_detector
   has_and_belongs_to_many :reasons
   has_and_belongs_to_many :post_tags, class_name: 'DomainTag'
+  has_many :post_spam_domains
   has_and_belongs_to_many :spam_domains
   has_many :feedbacks, dependent: :destroy
   has_many :deletion_logs, dependent: :destroy

--- a/app/models/post_spam_domain.rb
+++ b/app/models/post_spam_domain.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class PostSpamDomain < ApplicationRecord
+  self.table_name = 'posts_spam_domains'
+  belongs_to :post
+  belongs_to :spam_domain
+  belongs_to :added_by, class_name: 'User'
+
+  def custom_delete
+    self.class.where(attributes).delete_all
+  end
+end

--- a/app/models/spam_domain.rb
+++ b/app/models/spam_domain.rb
@@ -4,6 +4,7 @@ class SpamDomain < ApplicationRecord
   include Websocket
 
   has_and_belongs_to_many :posts, after_add: :setup_review
+  has_many :post_spam_domains
   has_and_belongs_to_many :domain_tags, after_add: :check_dq
   has_and_belongs_to_many :domain_groups
   has_one :review_item, as: :reviewable

--- a/app/models/spam_domain.rb
+++ b/app/models/spam_domain.rb
@@ -3,8 +3,8 @@
 class SpamDomain < ApplicationRecord
   include Websocket
 
-  has_and_belongs_to_many :posts, after_add: :setup_review
   has_many :post_spam_domains
+  has_many :posts, through: :post_spam_domains, after_add: :setup_review
   has_and_belongs_to_many :domain_tags, after_add: :check_dq
   has_and_belongs_to_many :domain_groups
   has_one :review_item, as: :reviewable

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -187,7 +187,15 @@
 <% if @post.spam_domains.any? %>
   <ul class="post-domain-list">
     <% @post.spam_domains.each do |d| %>
-      <li><%= render 'spam_domains/domain', domain: d, occurances: true %></li>
+      <li>
+        <%= render 'spam_domains/domain', domain: d, occurances: true %>
+        <% if current_user&.has_role?(:core) && !(psd = PostSpamDomain.find_by(post: @post, spam_domain: d)).added_by.nil? %>
+          <%= link_to "remove domain", remove_post_domain_path(id: @post.id, domain_id: d.id), class: 'btn-sm btn-danger', method: :post %>
+          <% if current_user&.has_role?(:admin) %>
+            <i class="text-muted">(added by <%= psd.added_by.username %>, user_id: <%= psd.added_by.id %>)</i>
+          <% end %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% else %>
@@ -198,7 +206,7 @@
   <%= form_tag add_post_domain_path, method: :post do %>
     <%= hidden_field_tag :post_id, @post.id %>
     <%= text_field_tag :domain_name %>
-    <%= submit_tag 'Add Domain', data: { confirm: "Are you sure you want to add this domain? Only a developer can undo this action." }, class: 'btn btn-primary btn-sm' %>
+    <%= submit_tag 'Add Domain', class: 'btn btn-primary btn-sm' %>
   <% end %>
 <% end %>
 <br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,7 +369,8 @@ Rails.application.routes.draw do
     post ':post_id/feedback',     to: 'posts#feedback',             as: :post_feedback
     get  ':id/feedback/clear',    to: 'feedbacks#clear',            as: :clear_post_feedback
     post ':id/admin_flag',        to: 'posts#needs_admin',          as: :admin_flag_post
-    post ':id/add_domain',        to: 'posts#add_domain',           as: :add_post_domain
+    post ':id/domains/add',       to: 'posts#add_domain',           as: :add_post_domain
+    post ':id/domains/remove',    to: 'posts#remove_domain',        as: :remove_post_domain
   end
 
   scope 'posts' do

--- a/db/migrate/20200713142427_add_added_by_to_posts_spam_domains.rb
+++ b/db/migrate/20200713142427_add_added_by_to_posts_spam_domains.rb
@@ -1,0 +1,5 @@
+class AddAddedByToPostsSpamDomains < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :posts_spam_domains, :added_by, foreign_key: { to_table: :users }
+  end
+end


### PR DESCRIPTION
This does exactly what the title says, continuing my work from https://github.com/Charcoal-SE/metasmoke/commit/0b2d47e4aba25b32f84aa4a542e8440d6765501c. The only problem is that I needed to add an attribute on the join table `posts_spam_domains`, but when I created a model for that table everything got angry about a compound primary key and the lack of an `id` column. I don't know what the best solution is here.