### PR TITLE
The navbar was very long, make it less long

### DIFF
--- a/app/javascript/cable/topbar.js
+++ b/app/javascript/cable/topbar.js
@@ -28,7 +28,7 @@ $(() => {
   });
 
   setInterval(() => {
-    const $status = $('.navbar .status');
+    const $status = $('.navbar #smokedetector-status');
     const lastPing = parseFloat($status.data('last-ping')) * 1e3;
     const ago = Date.now() - lastPing;
     const title = `Last ping was ${moment(lastPing).fromNow()}.`;

--- a/app/views/custom_registrations/edit.html.erb
+++ b/app/views/custom_registrations/edit.html.erb
@@ -81,6 +81,13 @@
       </div>
     </div>
 
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <h3>Stack Overflow Channel email</h3>
+        <%= link_to 'Get sign up information for Stack Overflow Channels', channels_email_path, class: 'btn btn-primary' %>
+      </div>
+    </div>
+
     <div class="panel panel-danger">
       <div class="panel-body">
         <h3 class="text-danger">Cancel my account</h3>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,3 +1,9 @@
+<form role="search">
+  <div class="form-group">
+    <input type="text" id="search" class="form-control" placeholder="Search reasons">
+  </div>
+</form>
+
 <p>
   <strong><%= @reasons.count %></strong>
   <%= "filter".pluralize(@reasons.count) %> have caught

--- a/app/views/dashboard/new_dash.html.erb
+++ b/app/views/dashboard/new_dash.html.erb
@@ -99,9 +99,3 @@
     <li><strong><%= Post.autoflagged.fp.count %></strong> (<%= ((Post.autoflagged.fp.count.to_f / Post.autoflagged.count) * 100).round(2) %>%) FP</li>
   </ul>
 </p>
-
-<h3>Links</h3>
-<ul>
-  <li><a href="https://charcoal-se.org/">What are Charcoal and SmokeDetector?</a></li>
-  <li><%= link_to 'Spam/Autoflagging by site (including undeleted)', site_dash_path %></li>
-</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,7 @@
             <%= nav_link DomainTagsController, label: 'Domain Tags' %>
             <%= nav_link DomainGroupsController, label: 'Domain Groups' %>
             <li role="separator" class="divider"></li>
+            <%= nav_link DashboardController, action: :site_dash, label: 'Site Dashboard' %>
             <%= nav_link GraphsController, label: 'Graphs' %>
             <%= nav_link StackExchangeUsersController, label: 'Spammers', action: :sites %>
           <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,8 +52,6 @@
         <ul class="nav navbar-nav">
           <%= nav_link PostsController %>
           <li class='<%= (controller.class == DashboardController && controller.action_name == :index) ? "active" : "" %>'><%= link_to "reasons", reasons_path %></li>
-          <%= nav_link GraphsController %>
-          <%= nav_link SearchController %>
           <% Rack::MiniProfiler.step('Rendering: layouts/application/nav/review') do %>
           <% if user_signed_in? && current_user.has_role?("reviewer") %>
             <% q_counts = redis.smembers("review_queues").map { |i| [i.to_i, redis.scard("review_queue/#{i}/unreviewed")] }.to_h %>
@@ -74,14 +72,14 @@
             <% end %>
           <% end %>
           <% end %>
-          <%= nav_link FlagSettingsController, action: :dashboard, label: 'flagging',
-                       active: [FlagConditionsController, FlagLogController] %>
-
           <%= nav_dropdown AdminController, label: 'tools' do %>
             <%= nav_link SpamDomainsController, label: 'Domains' %>
             <%= nav_link DomainTagsController, label: 'Domain Tags' %>
             <%= nav_link DomainGroupsController, label: 'Domain Groups' %>
             <li role="separator" class="divider"></li>
+            <%= nav_link FlagSettingsController, action: :dashboard, label: 'Flagging',
+                         active: [FlagConditionsController, FlagLogController] %>
+            <%= nav_link GraphsController, label: 'Graphs' %>
             <%= nav_link StackExchangeUsersController, label: 'Spammers', action: :sites %>
           <% end %>
 
@@ -141,13 +139,6 @@
             }
           } %>
         </ul>
-        <% if controller.class == DashboardController && controller.action_name == 'index' %>
-          <form class="navbar-form navbar-right" role="search">
-            <div class="form-group">
-              <input type="text" id="search" class="form-control" placeholder="Search reasons">
-            </div>
-          </form>
-        <% end %>
         <ul class="nav navbar-nav navbar-right">
           <% if user_signed_in? %>
             <%= nav_dropdown label: current_user.username || current_user.email do %>
@@ -177,9 +168,9 @@
               <code><%= CurrentCommit.first(7) %></code>
             <% end %>
           <% end %>
-          <% if controller.class == DashboardController && controller.action_name == 'index' %>
-            <li class="search-icon hidden-xs"><a class="glyphicon glyphicon-search" href=#><span class="sr-only">Search</span></a></li>
-          <% end %>
+          <li class="nav-link <%= (controller.class == SearchController && controller.action_name.to_sym == :index) ? "active" : "" %>">
+            <%= link_to '', search_path, class: 'glyphicon glyphicon-search' %>
+          </li>
         </ul>
       </div><!-- /.navbar-collapse -->
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
         <ul class="nav navbar-nav">
           <%= nav_link PostsController %>
           <% if !user_signed_in? %>
-            <%= nav_link GraphsController, label: 'Graphs' %>
+            <%= nav_link GraphsController, label: 'graphs' %>
           <% end %>
           <li class='<%= (controller.class == DashboardController && controller.action_name == :index) ? "active" : "" %>'><%= link_to "reasons", reasons_path %></li>
           <% Rack::MiniProfiler.step('Rendering: layouts/application/nav/review') do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,9 @@
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav">
           <%= nav_link PostsController %>
+          <% if !user_signed_in? %>
+            <%= nav_link GraphsController, label: 'Graphs' %>
+          <% end %>
           <li class='<%= (controller.class == DashboardController && controller.action_name == :index) ? "active" : "" %>'><%= link_to "reasons", reasons_path %></li>
           <% Rack::MiniProfiler.step('Rendering: layouts/application/nav/review') do %>
           <% if user_signed_in? && current_user.has_role?("reviewer") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,8 +77,6 @@
             <%= nav_link DomainTagsController, label: 'Domain Tags' %>
             <%= nav_link DomainGroupsController, label: 'Domain Groups' %>
             <li role="separator" class="divider"></li>
-            <%= nav_link FlagSettingsController, action: :dashboard, label: 'Flagging',
-                         active: [FlagConditionsController, FlagLogController] %>
             <%= nav_link GraphsController, label: 'Graphs' %>
             <%= nav_link StackExchangeUsersController, label: 'Spammers', action: :sites %>
           <% end %>
@@ -131,6 +129,7 @@
           <% end %>
 
           <%= nav_link StatusController, attrs: {
+            id: 'smokedetector-status',
             class: ['status', "status-#{SmokeDetector.status_color}"],
             data: {
               last_ping: SmokeDetector.select(:last_ping).order(last_ping: :desc).first.last_ping.to_f,
@@ -170,6 +169,10 @@
           <% end %>
           <li class="nav-link <%= (controller.class == SearchController && controller.action_name.to_sym == :index) ? "active" : "" %>">
             <%= link_to '', search_path, class: 'glyphicon glyphicon-search' %>
+          </li>
+          <% flagging_status = FlagSetting['flagging_enabled'] == '0' ? 'critical' : (FlagSetting['dry_run'] == '1' ? 'warning' : 'good') %>
+          <li class="nav-link status status-<%= flagging_status %> <%= (controller.class == FlagSettingsController && controller.action_name.to_sym == :dashboard) ? "active" : "" %>">
+            <%= link_to '', flagging_path, class: 'glyphicon glyphicon-flag' %>
           </li>
         </ul>
       </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
Here are the changes I'm proposing:
- Remove Search from the nav and replace it with a magnifying glass on the far right.
- The magnifying glass used to exist only on /reasons, that functionality has been moved to a search bar at the top of /reasons
- Move graphs under the tools menu and do some reorganizing in there.
- Move flagging dashboard to a flag icon in the top right with a flagging status indicator color under it
- Remove links at the bottom of the homepage and move them into the tools menu
- Add link to get a channels email to the edit profile page