### PR TITLE
Verify core before mass tagging

### DIFF
--- a/app/controllers/domain_tags_controller.rb
+++ b/app/controllers/domain_tags_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class DomainTagsController < ApplicationController
-  before_action :authenticate_user!, only: %i[add remove edit update destroy add_post remove_post]
-  before_action :verify_core, only: %i[add remove edit update add_post remove_post]
+  before_action :authenticate_user!, only: %i[add remove edit update destroy add_post remove_post submit_mass_tag]
+  before_action :verify_core, only: %i[add remove edit update add_post remove_post submit_mass_tag]
   before_action :verify_admin, only: [:destroy]
   before_action :set_domain_tag, only: %i[show edit update destroy]
   before_action :verify_developer, only: [:merge]


### PR DESCRIPTION
Unauthorized users may apply arbitrary tags to any domain otherwise.