### PR TITLE
Actually restrict db dumps to core users

### DIFF
--- a/app/controllers/dumps_controller.rb
+++ b/app/controllers/dumps_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DumpsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :verify_core
   before_action :set_dump, only: %i[show edit update destroy]
 
   # GET /dumps


### PR DESCRIPTION
Currently it appears that anyone with the correct url can obtain the db and redis dump.