### PR TITLE
Restrict destroying domain groups to admin

### DIFF
--- a/app/controllers/domain_groups_controller.rb
+++ b/app/controllers/domain_groups_controller.rb
@@ -3,6 +3,7 @@
 class DomainGroupsController < ApplicationController
   before_action :set_group, only: %i[show edit update destroy emails]
   before_action :verify_core, only: %i[new create edit update]
+  before_action :verify_admin, only: :destroy
 
   def index
     @groups = DomainGroup.joins('LEFT JOIN domain_groups_spam_domains j ON domain_groups.id = j.domain_group_id')


### PR DESCRIPTION
Does not appear to have any restriction otherwise; not a severe issue as domain groups have nothing to do with spam detection.