### PR TITLE
Prevent shell injection on grep

### DIFF
--- a/app/controllers/developer_controller.rb
+++ b/app/controllers/developer_controller.rb
@@ -13,7 +13,10 @@ class DeveloperController < ApplicationController
 
   def production_log
     @log = if params[:grep].present?
-             `tail -n 10000 log/production.log | grep -E '#{params[:grep]}' -C #{params[:context]} --color=never`
+           unless params[:grep].instance_of?(String) && params[:context].instance_of?(Integer)
+             raise ActionController::RoutingError, 'Not Found'
+           end
+             `tail -n 10000 log/production.log | grep -E '#{params[:grep].tr("'", '')}' -C '#{params[:context]}' --color=never`
            else
              `tail -n 1000 log/production.log`
            end


### PR DESCRIPTION
This effectively gives any developer UNRESTRICTED SHELL ACCESS.