### PR TITLE
Don't tell non-admin "Access denied" when cleared their feedback

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -34,7 +34,12 @@ class FeedbacksController < ApplicationController
 
     f.post.update_feedback_cache
 
-    redirect_to clear_post_feedback_path(f.post_id)
+    feedbacks_after_delete = Feedback.unscoped.where(post_id: f.post_id)
+    if verify_access(feedback_after_delete)
+      redirect_to clear_post_feedback_path(f.post_id)
+    else
+      redirect_to post_path(id: f.post_id)
+    end
   end
 
   # POST /feedbacks

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -34,8 +34,7 @@ class FeedbacksController < ApplicationController
 
     f.post.update_feedback_cache
 
-    feedbacks_after_delete = Feedback.unscoped.where(post_id: f.post_id)
-    if verify_access(feedback_after_delete)
+    if verify_access(Feedback.unscoped.where(post_id: f.post_id))
       redirect_to clear_post_feedback_path(f.post_id)
     else
       redirect_to post_path(id: f.post_id)


### PR DESCRIPTION
Currently, if an non-admin user has one and only one feedback on a certain post, when he/she deleted that feedback, he/she is redirected to clear_feedback_path, which gives access denied; this is confusing as the feedback is indeed successfully deleted.