### PR TITLE
Check if conflict before removing posts from review

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -191,7 +191,7 @@ class Feedback < ApplicationRecord
     feedback_classes = all_feedback.uniq
     # If there is only one feedback class, there is no conflict at all
     return false if feedback_classes.length == 1
-    feedback_counts = feedback_classes.map do |fc| [fc, all_feedback.count(fc)] }.to_h
+    feedback_counts = feedback_classes.map { |fc| [fc, all_feedback.count(fc)] }.to_h
     counts = feedback_counts.values
     not(counts.max >= (counts.max(2)[1] || counts.max) + 2)
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -117,12 +117,10 @@ class Feedback < ApplicationRecord
 
   # Keep this block last to make sure any corrections or deletions have been made before we check count
   after_create do
-    if post.feedbacks.count >= 2 && post.review_item&.completed == false
-      if check_if_conflict_unresolvable(post)
-        post.review_item.update(completed: false)
-      else
-        post.review_item.update(completed: true)
-      end
+    if check_if_conflict_unresolvable(post)
+      post.review_item.update(completed: false)
+    else
+      post.review_item.update(completed: true)
     end
   end
 
@@ -190,7 +188,7 @@ class Feedback < ApplicationRecord
     all_feedback = post_to_check.feedbacks.map { |fb| fb.feedback_type[0] }
     feedback_classes = all_feedback.uniq
     # If there is only one feedback class, there is no conflict at all
-    return false if feedback_classes.length == 1
+    return false if feedback_classes.length == 1 && all_feedback.length > 1
     feedback_counts = feedback_classes.map { |fc| [fc, all_feedback.count(fc)] }.to_h
     counts = feedback_counts.values
     counts.max < (counts.max(2)[1] || counts.max) + 2

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -118,7 +118,7 @@ class Feedback < ApplicationRecord
   # Keep this block last to make sure any corrections or deletions have been made before we check count
   after_create do
     if post.feedbacks.count >= 2 && post.review_item&.completed == false
-      if check_if_conflict_unresolvable(post):
+      if check_if_conflict_unresolvable(post)
         post.review_item.update(completed: false)
       else
         post.review_item.update(completed: true)

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -193,7 +193,7 @@ class Feedback < ApplicationRecord
     return false if feedback_classes.length == 1
     feedback_counts = feedback_classes.map { |fc| [fc, all_feedback.count(fc)] }.to_h
     counts = feedback_counts.values
-    not(counts.max >= (counts.max(2)[1] || counts.max) + 2)
+    counts.max < (counts.max(2)[1] || counts.max) + 2
   end
     
   def check_for_user_assoc

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -187,17 +187,13 @@ class Feedback < ApplicationRecord
   end
 
   def check_if_conflict_unresolvable(post_to_check)
-    all_feedback = post_to_check.feedbacks.map { |fb|
-      fb.feedback_type[0]
-    }
+    all_feedback = post_to_check.feedbacks.map { |fb| fb.feedback_type[0] }
     feedback_classes = all_feedback.uniq
     # If there is only one feedback class, there is no conflict at all
     return false if feedback_classes.length == 1
-    feedback_counts = feedback_classes.map { |fc|
-      [fc, all_feedback.count(fc)]
-    }.to_h
+    feedback_counts = feedback_classes.map do |fc| [fc, all_feedback.count(fc)] }.to_h
     counts = feedback_counts.values
-    return ! counts.max >= (counts.max(2)[1] || counts.max) + 2
+    not(counts.max >= (counts.max(2)[1] || counts.max) + 2)
   end
     
   def check_for_user_assoc

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -195,7 +195,7 @@ class Feedback < ApplicationRecord
     counts = feedback_counts.values
     counts.max < (counts.max(2)[1] || counts.max) + 2
   end
-    
+
   def check_for_user_assoc
     return if chat_host.nil? || chat_user_id.nil?
 


### PR DESCRIPTION
We won't generally want to remove a post from the review queue when the feedback is `['tpu', 'fp']`.