### PR TITLE
Not to unilaterally nuke posts

### DIFF
--- a/app/models/spam_wave.rb
+++ b/app/models/spam_wave.rb
@@ -7,7 +7,7 @@ class SpamWave < ApplicationRecord
   serialize :conditions, JSON
 
   validates :name, presence: true
-  validates :max_flags, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 6 }
+  validates :max_flags, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
   validate :check_min_accuracy
   validate :max_expiry
 


### PR DESCRIPTION
Currently, the spam wave tool allows posts matching certain regex to be flagged with up to 6 flags. This does not look good, as we can make mistakes and spam wave flags are not subject to user's flag conditions. This PR changes the value to 5 so that no post is unilaterally nuked by autoflags.