### PR TITLE
Move [MS] link to beginning of feedback-recieved message

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -157,7 +157,7 @@ class Feedback < ApplicationRecord
     unless post.id == Post.last.id
       host = 'metasmoke.erwaysoftware.com'
       link = url_helpers.url_for controller: :posts, action: :show, id: post.id, host: host
-      message += " on [#{SmokeDetectorsHelper.escape_markdown post.title}](#{post.link}) \\[[MS](#{link})]"
+      message += " on \\[[MS](#{link})] [#{SmokeDetectorsHelper.escape_markdown post.title}](#{post.link})"
     end
     ActionCable.server.broadcast 'smokedetector_messages', message: message
   end


### PR DESCRIPTION
Changes the message formats from:

> tpu- feedback received  
> tpu- feedback received on [Java Can't display text in JTextBox](https://www.youtube.com/watch?v=dQw4w9WgXcQ) \[[MS](https://www.youtube.com/watch?v=dQw4w9WgXcQ)]

to:

> tpu- feedback received  
> tpu- feedback recieved on \[[MS](https://www.youtube.com/watch?v=dQw4w9WgXcQ)] [Java Can't display text in JTextBox](https://www.youtube.com/watch?v=dQw4w9WgXcQ)

...respectively.

[Requested by Daniil](https://chat.stackexchange.com/transcript/message/55354299#55354299):

> @Makyen cc anyone else Can we have the MS link on feedback received... messages moved towards the beginning of the message as sometimes I have difficulty clicking the link as it ends up right under the star/flag buttons.