### PR TITLE
Validate against months parameter

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -74,7 +74,7 @@ class DashboardController < ApplicationController
     @site = Site.find(params[:site_id])
 
     @months = params[:months].to_s.empty? ? 3 : params[:months].to_i
-    @months < 1 && @months = 1
+    @months = 1 if @months < 1
     @months_string = @months == 1 ? 'month' : "#{@months} months"
 
     @all_posts = @posts.where(site_id: @site.id)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -74,7 +74,8 @@ class DashboardController < ApplicationController
     @site = Site.find(params[:site_id])
 
     @months = params[:months].to_s.empty? ? 3 : params[:months].to_i
-    @months_string = @months <= 1 ? 'month' : "#{@months} months"
+    @months < 1 && @months = 1
+    @months_string = @months = 1 ? 'month' : "#{@months} months"
 
     @all_posts = @posts.where(site_id: @site.id)
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -75,7 +75,7 @@ class DashboardController < ApplicationController
 
     @months = params[:months].to_s.empty? ? 3 : params[:months].to_i
     @months < 1 && @months = 1
-    @months_string = @months = 1 ? 'month' : "#{@months} months"
+    @months_string = @months == 1 ? 'month' : "#{@months} months"
 
     @all_posts = @posts.where(site_id: @site.id)
 


### PR DESCRIPTION
It appears that site dashboard will have erroneous behaviour and take relatively long time to run when a large negative "months" parameter is supplied (example: `-10000000000000000000000000000000000000000`).

This PR validates months parameter and ensures that it is not less than 1, which is the value "enforced" in the corresponding javascript.