### PR TITLE
JavaScript: Don't add multiple identical event handlers

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -4,14 +4,14 @@ import { onLoad } from './util';
 const debug = createDebug('ms:comments');
 
 onLoad(() => {
-  $(document).on('click', '.new-comment', ev => {
+  $(document.body).on('click', '.new-comment', ev => {
     debug('.new-comment click');
     ev.preventDefault();
     $('.add-comment').show();
     $(ev.target).remove();
   });
 
-  $(document).on('click', '.comment-edit', async ev => {
+  $(document.body).on('click', '.comment-edit', async ev => {
     ev.preventDefault();
 
     const $comment = $(ev.target).parents('.post-comment, .abuse-comment');

--- a/app/javascript/data.js
+++ b/app/javascript/data.js
@@ -206,7 +206,7 @@ route('/data', async () => {
     addDataListRow();
   });
 
-  $(document).on('change', '.data-type-limit, .data-type-select', ({ target }) => {
+  $(document.body).on('change', '.data-type-limit, .data-type-select', ({ target }) => {
     const $this = $(target);
     const isLimit = $this.hasClass('data-type-limit');
     const $limit = isLimit ? $this : $this.siblings(isLimit ? '.data-type-select' : '.data-type-limit').first();
@@ -219,7 +219,7 @@ route('/data', async () => {
     }
   });
 
-  $(document).on('change', '.data-type-select', ({ target }) => {
+  $(document.body).on('change', '.data-type-select', ({ target }) => {
     const $this = $(target);
     if ($this.val().length > 0) {
       displaySchema($this.val());

--- a/app/javascript/graphs.js
+++ b/app/javascript/graphs.js
@@ -1,12 +1,11 @@
-import { route } from './util';
-
 /* globals Highcharts */
 
-route('/flagging/conditions/sandbox', () => {
-  $(document).ajaxSuccess((ev, xhr, options) => {
+$(document).ajaxSuccess((ev, xhr, options) => {
+  // Equivalent detection to route() from './util', but doesn't add multiple listeners.
+  if (window.location.pathname === '/flagging/conditions/sandbox') {
     if (options.url.indexOf('/graphs/af_accuracy') >= 0) {
       Highcharts.charts[0].update({ series: [{ marker: { enabled: false }, linecap: 'butt' }, { marker: { enabled: false }, linecap: 'butt' },
         { yAxis: 1, marker: { enabled: false }, linecap: 'butt' }] });
     }
-  });
+  }
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -117,7 +117,7 @@ const metasmoke = window.metasmoke = {
     initFormParamCleanups: () => {
       const formParameterCleanups = [];
 
-      $(document).on('submit', 'form', ev => {
+      $(document.body).on('submit', 'form', ev => {
         const tgt = $(ev.target);
         if (formParameterCleanups.indexOf(tgt[0]) === -1) {
           ev.preventDefault();
@@ -129,7 +129,7 @@ const metasmoke = window.metasmoke = {
     },
 
     setupAjaxDeduplicator: () => {
-      $(document).on('ajax:beforeSend', 'form[data-deduplicate]', (ev, xhr) => {
+      $(document.body).on('ajax:beforeSend', 'form[data-deduplicate]', (ev, xhr) => {
         const $tgt = $(ev.target);
         if (!$tgt.data('dedup-uuid')) {
           $tgt.attr('data-dedup-uuid', uuid4());
@@ -157,7 +157,7 @@ const metasmoke = window.metasmoke = {
     },
 
     setPostRenderModes: () => {
-      $(document).on('click', '.post-render-mode', ev => {
+      $(document.body).on('click', '.post-render-mode', ev => {
         const mode = $(ev.target).data('render-mode');
         metasmoke.storage['post-render-mode'] = mode;
         metasmoke.debug(`default render mode updated to ${mode}`);
@@ -167,7 +167,7 @@ const metasmoke = window.metasmoke = {
         $(`.post-render-mode[data-render-mode="${metasmoke.storage['post-render-mode']}"]`).tab('show');
       }
 
-      $(document).on('DOMNodeInserted', '.post-body, .review-item-container', () => {
+      $(document.body).on('DOMNodeInserted', '.post-body, .review-item-container', () => {
         $(`.post-render-mode[data-render-mode="${metasmoke.storage['post-render-mode']}"]`).tab('show');
       });
     }

--- a/app/javascript/review.js
+++ b/app/javascript/review.js
@@ -1,7 +1,7 @@
 import { onLoad, route, installSelectpickers } from './util';
 
 onLoad(() => {
-  $(document).on('ajax:success', 'a.feedback-button[data-remote]', e => {
+  $(document.body).on('ajax:success', 'a.feedback-button[data-remote]', e => {
     if (!$(e.target).hasClass('on-post')) {
       $('.post-cell-' + e.target.dataset.postId).remove();
       e.target.closest('tr').remove();
@@ -81,12 +81,15 @@ route(/\/review\/[\w-]+\/?\d*$/i, async () => {
     loadNextPost();
   }
 
-  $(document).on('ajax:success', '.review-submit-link', () => {
+  // The document will continue to exist even if we navigate to another page.
+  // Thus, when we navigate back to this route, an additional listener will
+  // be added. The document.body is replaced upon each SPA navigation.
+  $(document.body).on('ajax:success', '.review-submit-link', () => {
     $('.review-item-container').text('Loading...');
     loadNextPost();
   });
 
-  $(document).on('click', '.review-next-link', () => {
+  $(document.body).on('click', '.review-next-link', () => {
     $('.review-item-container').text('Loading...');
     loadNextPost();
   });
@@ -115,7 +118,7 @@ route(/\/review\/[\w-]+\/?\d*$/i, async () => {
 });
 
 route(/\/review\/untagged-domains(\/\d*)?/, () => {
-  $(document).on('ajax:success', '.review-add-domain-tag', (e, data) => {
+  $(document.body).on('ajax:success', '.review-add-domain-tag', (e, data) => {
     const $noTags = $('.no-tags');
     if ($noTags.length > 0) {
       $noTags.remove();

--- a/app/javascript/site_settings.js
+++ b/app/javascript/site_settings.js
@@ -34,14 +34,14 @@ route('/admin/settings', () => {
     $(ev.target).html(`<input type="${type}" step="${step}" class="editing-value form-control input-sm" value="${value}" />`);
   });
 
-  $(document).on('click', () => {
+  $(document.body).on('click', () => {
     $('.editing-value').each((i, e) => {
       const value = $(e).val();
       $(e).parent().text(value);
     });
   });
 
-  $(document).on('keypress', '.editing-value', async ev => {
+  $(document.body).on('keypress', '.editing-value', async ev => {
     if (ev.charCode === 13) {
       const name = $(ev.target).parent().data('name');
       const value = $(ev.target).val();

--- a/app/javascript/util.js
+++ b/app/javascript/util.js
@@ -22,9 +22,13 @@ $(document).on('turbolinks:load', () => {
 
 $(window).on('beforeunload', () => {
   debug('onbeforeunload');
-  const route = routes.find(route => route.current) || { exit: () => {} };
-  route.current = false;
-  route.exit.call(null);
+  const currentRoutes = routes.filter(route => route.current);
+  currentRoutes.forEach(route => {
+    route.current = false;
+    if (typeof route.exit === 'function') {
+      route.exit.call(null);
+    }
+  });
 });
 
 export function route(path, enter, exit = () => {}) {


### PR DESCRIPTION
Our JavaScript was adding multiple identical event handlers, which could result in various unintended operation (e.g. multiple AJAX requests to the same route for a single click).

In this PR:
- Changes the code so that the listeners are not duplicated
- Runs all the "current" `route.exit()` functions on `beforeunload`, rather than just the first one found

### The duplicate listeners problem
In util.js, we have a `onLoad()` which is called to add a function to be executed whenever the Single Page Application (SPA) "lands" on a new "page". There's a `route` function, which is `onLoad()`, but only when the URL's `pathname` matches the value supplied when calling `route`.

In either `onLoad` or `route` routines, our JavaScript was adding anonymous functions as event listeners to the `document`. However, in a SPA, the `document` never changes, even when you transition from one "page" to the next. Because all the listeners were all anonymous functions, there was no way for the event add/remove logic to know that the handler had already been added, so an additional copy of each of those handlers was added whenever there was a page transition (for ones added in an `onLoad()` function), or a page transition when the `pathname` matched for those added in `route()` routines. As a result, when navigating around on MS event handlers would just accumulate every time one went to a page which added them.

The solution adopted here was to change all of the event handlers to be added to `document.body`, rather than `document`. In the SPA we use, the `document.body` is completely replaced upon transition to a new "page". Thus, the old event listeners no longer exist in the `document`, and are not duplicated when new ones are added upon "page" load.

In one case, the graphs for the flagging conditions sandbox (already non-functional), the listener has to be on the `document`, so code adding the listener was moved out of a `route()` and an equivalent `pathname` check added to the event handler which is added once on the `document`. Note that the flagging conditions sandbox page already appears non-functional for me, so the page is still non-functional after this change.

While I'm fairly confident in this PR's changes, it's not something I want to push to production late in my day on Friday. Assuming nobody finds any issues with the code in the meantime, I expect to push this fix to production shortly after I get back in on Saturday.