### PR TITLE
Improve search performance by removing unnecessary overheads

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -118,7 +118,6 @@ class SearchController < ApplicationController
                   end
     end
 
-    # rubocop:disable Metrics/BlockLength
     respond_to do |format|
       format.html do
         @counts_by_accuracy_group = @results.group(:is_tp, :is_fp, :is_naa).count

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -64,8 +64,6 @@ class SearchController < ApplicationController
     end
 
     @results = @results.where(search_string.join(params[:or_search].present? ? ' OR ' : ' AND '), **search_params)
-                       .order(Arel.sql('`posts`.`created_at` DESC'))
-
     @results = @results.includes(:reasons).includes(:feedbacks) if params[:option].nil?
 
     if params[:has_no_feedback] == '1'
@@ -145,6 +143,7 @@ class SearchController < ApplicationController
           @results = @results.paginate(page: params[:page], per_page: per_page,
                                        total_entries: @total_count)
         end
+        @results = @results.order(Arel.sql('`posts`.`created_at` DESC'))
 
         @sites = Site.where(id: @results.map(&:site_id)).to_a unless params[:option] == 'graphs'
         render :search

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -118,6 +118,7 @@ class SearchController < ApplicationController
                   end
     end
 
+    # rubocop:disable Metrics/BlockLength
     respond_to do |format|
       format.html do
         @counts_by_accuracy_group = @results.group(:is_tp, :is_fp, :is_naa).count
@@ -126,7 +127,6 @@ class SearchController < ApplicationController
         end.to_h
         @total_count = @counts_by_accuracy_group.values.sum
 
-        # rubocop:disable Metrics/BlockLength
         @results = case params[:feedback_filter]
                    when 'tp'
                      @results.where(is_tp: true)
@@ -144,7 +144,7 @@ class SearchController < ApplicationController
                      @results.paginate(page: params[:page], per_page: per_page,
                                        total_entries: @total_count)
                    end.order(Arel.sql('`posts`.`created_at` DESC'))
-        # rubocop:enable Metrics/BlockLength
+
         render :search
       end
       format.json do

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -126,25 +126,25 @@ class SearchController < ApplicationController
         end.to_h
         @total_count = @counts_by_accuracy_group.values.sum
 
-        case params[:feedback_filter]
-        when 'tp'
-          @results = @results.where(is_tp: true)
+        # rubocop:disable Metrics/BlockLength
+        @results = case params[:feedback_filter]
+                   when 'tp'
+                     @results.where(is_tp: true)
                              .paginate(page: params[:page], per_page: per_page,
                                        total_entries: @counts_by_feedback[:is_tp])
-        when 'fp'
-          @results = @results.where(is_fp: true)
+                   when 'fp'
+                     @results.where(is_fp: true)
                              .paginate(page: params[:page], per_page: per_page,
                                        total_entries: @counts_by_feedback[:is_fp])
-        when 'naa'
-          @results = @results.where(is_naa: true)
+                   when 'naa'
+                     @results.where(is_naa: true)
                              .paginate(page: params[:page], per_page: per_page,
                                        total_entries: @counts_by_feedback[:is_naa])
-        else
-          @results = @results.paginate(page: params[:page], per_page: per_page,
+                   else
+                     @results.paginate(page: params[:page], per_page: per_page,
                                        total_entries: @total_count)
-        end
-        @results = @results.order(Arel.sql('`posts`.`created_at` DESC'))
-
+                   end.order(Arel.sql('`posts`.`created_at` DESC'))
+        # rubocop:enable Metrics/BlockLength
         @sites = Site.where(id: @results.map(&:site_id)).to_a unless params[:option] == 'graphs'
         render :search
       end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -145,7 +145,6 @@ class SearchController < ApplicationController
                                        total_entries: @total_count)
                    end.order(Arel.sql('`posts`.`created_at` DESC'))
         # rubocop:enable Metrics/BlockLength
-        @sites = Site.where(id: @results.map(&:site_id)).to_a unless params[:option] == 'graphs'
         render :search
       end
       format.json do

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -38,8 +38,8 @@
     <% end %>
 
     <% if post.comments.any? && !hide_feedbacks %>
-      <span class="comment-hint text-muted" title="<%= pluralize(post.comments.count, 'comment') %>">
-        <span class="glyphicon glyphicon-comment"></span> &times;<%= post.comments.count %>
+      <span class="comment-hint text-muted" title="<%= pluralize(post.comments.size, 'comment') %>">
+        <span class="glyphicon glyphicon-comment"></span> &times;<%= post.comments.size %>
       </span>
     <% end %>
 

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -116,9 +116,7 @@
 
   <% if params[:option].nil? %>
     <table class="table">
-      <% @results.each do |post| %>
-        <%= render "posts/post", post: post %>
-      <% end %>
+      <%= render @results, collection: :post %>
     </table>
     <div class="text-center">
       <%= will_paginate @results, renderer: BootstrapPagination::Rails %>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -98,7 +98,7 @@
 <% if @results.present? %>
   <ul class="nav nav-tabs">
     <li role="presentation" class="<%= "active" if params[:option].nil? and (params[:feedback_filter].nil? or params[:feedback_filter] == 'all') %>">
-      <%= link_to "Results (#{@counts_by_accuracy_group.values.sum})", search_path(request.query_parameters.merge!({option: nil, feedback_filter: nil})) %>
+      <%= link_to "Results (#{@total_count})", search_path(request.query_parameters.merge!({option: nil, feedback_filter: nil})) %>
     </li>
     <li class="<%= 'active' if params[:feedback_filter] == 'tp' %>">
       <%= link_to "True positives (#{@counts_by_feedback[:is_tp]})", search_path(request.query_parameters.to_h.merge!({option: nil, feedback_filter: "tp"})) %>


### PR DESCRIPTION
This PR tries to increase search performance (fulltext/like/regex). On my local machine, there is a 40%~60% reduction in total response time with these changes applied.

Currently, our search implementation suffers from various unnecessary overhead.
1. `will_paginate` will perform a *separate* query to count the results, which means that instead of performing a fulltext/like/regex query once, we are currently performing it *twice* for no reason.
2. There is N+1 query problem in post/_post.html.erb by using `count` method to calculate post comment counts, which will always issue a database `COUNT(*)` query regardless if the collection is already loaded.
3. We are using primitive `each` for rendering collections, while rails have a much faster collection rendering API.

---

Note: 
The `COUNT(*)` query for deciding tp/fp/naa count takes most of the time. The actual loading of posts takes only a fraction of a second.