### PR TITLE
Index posts on spammer id

### DIFF
--- a/db/migrate/20210128031002_index_posts_on_stack_exchange_user_id.rb
+++ b/db/migrate/20210128031002_index_posts_on_stack_exchange_user_id.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class IndexPostsOnStackExchangeUserId < ActiveRecord::Migration[5.2]
+  def change
+    add_index :posts, :stack_exchange_user_id
+  end
+end


### PR DESCRIPTION
This index makes showing spammer 10x faster (on my machine), mainly because a full table scan on posts is no longer necessary.