### PR TITLE
Add routes for GitHub check_runs and check_suites WebHooks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -310,15 +310,15 @@ Rails.application.routes.draw do
   end
 
   scope 'github' do
-    post 'status_hook',             to: 'github#status_hook',             as: :github_status_hook
-    post 'pull_request_hook',       to: 'github#pull_request_hook',       as: :github_pull_request_hook
-    post 'ci_hook',                 to: 'github#ci_hook',                 as: :github_ci_hook
-    post 'update_deploy_to_master', to: 'github#update_deploy_to_master', as: :github_update_deploy_to_master
-    post 'metasmoke_push_hook',     to: 'github#metasmoke_push_hook',     as: :github_metasmoke_push_hook
-    post 'gollum',                  to: 'github#gollum_hook',             as: :github_gollum_hook
-    post 'project_status',          to: 'github#any_status_hook',         as: :github_project_status_hook
-    post 'pr_merge',                to: 'github#pullapprove_merge_hook',  as: :github_pr_merge_hook
-    post 'pr_approve/:number',      to: 'github#add_pullapprove_comment', as: :github_pr_approve_comment
+    post 'status_hook',                 to: 'github#status_hook',                 as: :github_status_hook
+    post 'pull_request_hook',           to: 'github#pull_request_hook',           as: :github_pull_request_hook
+    post 'ci_hook',                     to: 'github#ci_hook',                     as: :github_ci_hook
+    post 'update_deploy_to_master',     to: 'github#update_deploy_to_master',     as: :github_update_deploy_to_master
+    post 'metasmoke_push_hook',         to: 'github#metasmoke_push_hook',         as: :github_metasmoke_push_hook
+    post 'gollum',                      to: 'github#gollum_hook',                 as: :github_gollum_hook
+    post 'project_status',              to: 'github#any_status_hook',             as: :github_project_status_hook
+    post 'pr_merge',                    to: 'github#pullapprove_merge_hook',      as: :github_pr_merge_hook
+    post 'pr_approve/:number',          to: 'github#add_pullapprove_comment',     as: :github_pr_approve_comment
   end
 
   scope 'graphs' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,6 +317,8 @@ Rails.application.routes.draw do
     post 'metasmoke_push_hook',         to: 'github#metasmoke_push_hook',         as: :github_metasmoke_push_hook
     post 'gollum',                      to: 'github#gollum_hook',                 as: :github_gollum_hook
     post 'project_status',              to: 'github#any_status_hook',             as: :github_project_status_hook
+    post 'report_check_run_failure',    to: 'github#report_check_run_failure',    as: :github_report_check_run_failure
+    post 'report_check_suite_success',  to: 'github#report_check_suite_success',  as: :github_report_check_suite_success
     post 'pr_merge',                    to: 'github#pullapprove_merge_hook',      as: :github_pr_merge_hook
     post 'pr_approve/:number',          to: 'github#add_pullapprove_comment',     as: :github_pr_approve_comment
   end


### PR DESCRIPTION
In the past, MS has monitored CI testing status on our various repositories and forwarded reports of successes and failures on the master branch and PRs to SmokeDetector for SD to report into SE Chat. As we've moved to GitHub Actions (and away from Travis CI), that reporting has stopped working. The reason it stopped working is that the GitHub WebHook events are different for CI testing performed by external services (e.g. CircleCI and Travis CI) vs workflows run by GitHub Actions.

This PR:
* Adds a route `/github/report_check_suite_success` which receives Check Suites WebHook events indicating the completion of a full GitHub Actions workflow and forwards a message to SmokeDetector to be reported into SE Chat;
  * Expected to be active on: [metasmoke](https://github.com/Charcoal-SE/metasmoke), [charcoal-se.github.io](https://github.com/Charcoal-SE/charcoal-se.github.io), and [userscripts](https://github.com/Charcoal-SE/userscripts), but NOT [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector), because success for SD is already reported/acted upon based on the CircleCI testing. As some point in the future, we may want to look at adjusting some of how the SD ones are handled, so that all the CI testing is complete prior to merges, rather than just CircleCI, but this PR does not address that. The WebHook configuration for these events has already been added to these repositories.
  * Reports only for the CI on the master branch and/or PRs
* Adds a route `/github/report_check_run_failure` which receives Check Runs WebHook events indicating the completion of a full GitHub Actions workflow and forwards a message to SmokeDetector to be reported into SE Chat;
  * Expected to be active on: [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector), [metasmoke](https://github.com/Charcoal-SE/metasmoke), [charcoal-se.github.io](https://github.com/Charcoal-SE/charcoal-se.github.io), and [userscripts](https://github.com/Charcoal-SE/userscripts). The WebHook configuration for these events has already been added to these repositories.
  * Reports only for the CI on the master branch and/or PRs
* Fixes a bug in the code which prevented CircleCI successes from being reported for any repository other than metasmoke (actually, it prevented reporting unless there were 3 successful jobs for a commit, but the only repository we have which fulfilled that requirement is metasmoke;
* Adds a bunch of comments giving some background on what is happening in general and for some of the routes.
