### PR TITLE
Add a tab for displaying Markdown to other post views

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -48,7 +48,7 @@ class PostsController < ApplicationController
 
   # Render bodies on-demand for fancy expanding rows
   def body
-    @post = Post.where(id: params[:id]).select(:body, :id).includes(:reasons).first
+    @post = Post.where(id: params[:id]).select(:body, :markdown, :id).includes(:reasons).first
     render layout: false
   end
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -61,10 +61,13 @@
       <% if preload_post_body %>
         <ul class="nav nav-tabs" role="tablist">
           <li role="presentation" class="active">
-            <a href="#post-body-tab-<%= post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="markdown">
-              Markdown
-            </a>
+            <a href="#post-body-tab-<%= post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="text">Text</a>
           </li>
+          <% unless post.markdown.nil? %>
+            <li role="presentation">
+              <a href="#post-source-tab-<%= post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="markdown">Markdown</a>
+            </li>
+          <% end %>
           <li role="presentation">
             <a href="#preview-tab-<%= post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="rendered">Preview</a>
           </li>
@@ -90,10 +93,15 @@
               </div>
             <% end %>
           </div>
+          <% unless post.markdown.nil? %>
+            <div role="tabpanel" class="tab-pane" id="post-source-tab-<%= post.id %>">
+              <pre class="post-body-pre-block"><%= @post.markdown %></pre>
+            </div>
+          <% end %>
           <div role="tabpanel" class="tab-pane" id="preview-tab-<%= post.id %>">
             <div class="panel panel-default">
               <div class="panel-body">
-                <%= safe_render_markdown(post.body, scrubber: Post.scrubber) %>
+                <%= safe_render_markdown(post.markdown || post.body, scrubber: Post.scrubber) %>
               </div>
             </div>
           </div>

--- a/app/views/posts/body.html.erb
+++ b/app/views/posts/body.html.erb
@@ -1,7 +1,12 @@
 <ul class="nav nav-tabs" role="tablist">
   <li role="presentation" class="active">
-    <a href="#post-body-tab-<%= @post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="markdown">Markdown</a>
+    <a href="#post-body-tab-<%= @post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="text">Text</a>
   </li>
+  <% unless @post.markdown.nil? %>
+    <li role="presentation">
+      <a href="#post-source-tab-<%= @post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="markdown">Markdown</a>
+    </li>
+  <% end %>
   <li role="presentation">
     <a href="#preview-tab-<%= @post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="rendered">Preview</a>
   </li>
@@ -18,10 +23,15 @@
       </p>
     </div>
   </div>
+  <% unless @post.markdown.nil? %>
+    <div role="tabpanel" class="tab-pane" id="post-source-tab-<%= @post.id %>">
+      <pre class="post-body-pre-block"><%= @post.markdown %></pre>
+    </div>
+  <% end %>
   <div role="tabpanel" class="tab-pane" id="preview-tab-<%= @post.id %>">
     <div class="panel panel-default">
       <div class="panel-body">
-        <%= safe_render_markdown(@post.body, scrubber: Post.scrubber) %>
+        <%= safe_render_markdown(@post.markdown || @post.body, scrubber: Post.scrubber) %>
       </div>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -73,7 +73,7 @@
 <% unless @post.body.nil? %>
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active">
-      <a href="#post-body-tab" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="markdown">Text</a>
+      <a href="#post-body-tab" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="text">Text</a>
     </li>
     <% unless @post.markdown.nil? %>
       <li role="presentation">


### PR DESCRIPTION
When a tab was added for displaying a Markdown view for posts, it was only added in one of the three locations where posts are rendered. This PR adds the Markdown tab to the other two post views. It also resolves a bug preventing the user's selected view from being remembered correctly when the selected view was the text view.