### PR TITLE
Always show which post in feedback messages.

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -155,11 +155,9 @@ class Feedback < ApplicationRecord
     return if Feedback.where(post: post).where('feedback_type LIKE ?', "#{feedback_type[0]}%").where.not(id: id).exists?
 
     message = "#{feedback_type} feedback received"
-    unless post.id == Post.last.id
-      host = 'metasmoke.erwaysoftware.com'
-      link = url_helpers.url_for controller: :posts, action: :show, id: post.id, host: host
-      message += " on \\[[MS](#{link})] [#{SmokeDetectorsHelper.escape_markdown post.title}](#{post.link})"
-    end
+    host = 'metasmoke.erwaysoftware.com'
+    link = url_helpers.url_for controller: :posts, action: :show, id: post.id, host: host
+    message += " on \\[[MS](#{link})] [#{SmokeDetectorsHelper.escape_markdown post.title}](#{post.link})"
     ActionCable.server.broadcast 'smokedetector_messages', message: message
   end
 

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class FeedbackTest < ActiveSupport::TestCase
   test 'should cache feedback' do
     p = Post.new link: '//stackoverflow.com/questions/1'
+    p.title = 'A super title with description'
     p.save!
 
     refute p.is_tp
@@ -29,6 +30,7 @@ class FeedbackTest < ActiveSupport::TestCase
 
   test 'should invalidate feedback cache' do
     p = Post.new link: '//stackoverflow.com/questions/1'
+    p.title = 'A super title with description'
     p.save!
 
     true_feedback = Feedback.new


### PR DESCRIPTION
There are network delays in multiple places in the process of receiving the feedback to SD posting the message about the feedback in chat. This results in race conditions under various circumstances that, from time to time, make it unclear which post received the feedback when the message doesn't say.

In addition, now that we have a FIRE button in the feedback messages which have the post information, some people find it convenient to use that FIRE button, rather than tracking up to the associated SD report.