### PR TITLE
Run GitHub Actions CI on all branches and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,7 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
While a real change, this is a PR in order to test CI, and Check Run/Suite messages.

This PR is being created from a branch in my fork of the repo. In the past, I've had problems with CI not running properly on PR submitted from branches in my repository.