### PR TITLE
Limit "new usernames" in chat; add link to filtered users

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,6 +7,7 @@ class UserTest < ActiveSupport::TestCase
     post = Post.last
 
     u = User.new
+    u.username = 'Awesome Name'
     u.save!(validate: false)
 
     u.flag_conditions.new.save!(validate: false)


### PR DESCRIPTION
The adjusts the message sent to SmokeDetector when a new user is created on metasmoke:
* Redact usernames which are > 40 characters (which is the limit on usernames on SE);
* Add a link to the filtered user list to make it easier for admins to add the Flagger role, if appropriate.