### PR TITLE
Disable feedback buttons after clicking

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -444,3 +444,8 @@ body .profiler-results {
 .icon-nav-bar li a {
   padding: 0.7em;
 }
+
+a[data-disabled=disabled] {
+    pointer-events: none;
+    opacity: 0.5;
+}

--- a/app/javascript/feedbacks.js
+++ b/app/javascript/feedbacks.js
@@ -1,3 +1,5 @@
+import { onLoad } from './util';
+
 function disable(link) {
   link.tabIndex = -1;
   link.setAttribute('data-disabled', 'disabled');
@@ -17,20 +19,15 @@ const feedbackButtonClickHandler = () => {
   }, 2000);
 };
 
-const onLoadHandler = () => {
+onLoad(() => {
   document.querySelectorAll('.feedback-button').forEach(e => {
     e.addEventListener('click', feedbackButtonClickHandler);
   });
-};
+});
 
-const onBeforeCacheHandler = () => {
+document.addEventListener('turbolinks:before-cache', () => {
   document.querySelectorAll('.feedback-button').forEach(e => {
     e.removeEventListener('click', feedbackButtonClickHandler);
     enable(e);
   });
-  document.removeEventListener('turbolinks:load', onLoadHandler);
-  document.removeEventListener('turbolinks:before-cache', onBeforeCacheHandler);
-};
-
-document.addEventListener('turbolinks:load', onLoadHandler);
-document.addEventListener('turbolinks:before-cache', onBeforeCacheHandler);
+});

--- a/app/javascript/feedbacks.js
+++ b/app/javascript/feedbacks.js
@@ -1,27 +1,27 @@
 const clickHandler = () => {
-    // If one of the feedback buttons are clicked, disable **ALL**
-    // those buttons (which are actually <a> elements).
-    document.querySelectorAll('.feedback-button').forEach((e) => {
-        e.tabIndex = -1
-        e.setAttribute('data-disabled', 'disabled')
-    })
-}
+  // If one of the feedback buttons are clicked, disable **ALL**
+  // those buttons (which are actually <a> elements).
+  document.querySelectorAll('.feedback-button').forEach(e => {
+    e.tabIndex = -1;
+    e.setAttribute('data-disabled', 'disabled');
+  });
+};
 
 const onLoadHandler = () => {
-    document.querySelectorAll('.feedback-button').forEach((e) => {
-        e.addEventListener('click', clickHandler)
-    })
-}
+  document.querySelectorAll('.feedback-button').forEach(e => {
+    e.addEventListener('click', clickHandler);
+  });
+};
 
 const onBeforeCacheHandler = () => {
-    document.querySelectorAll('.feedback-button').forEach((e) => {
-        e.removeEventListener('click', clickHandler)
-        e.tabIndex = 0
-        e.removeAttribute('data-disabled')
-    })
-    document.removeEventListener('turbolinks:load', onLoadHandler)
-    document.removeEventListener('turbolinks:before-cache', onBeforeCacheHandler)
-}
+  document.querySelectorAll('.feedback-button').forEach(e => {
+    e.removeEventListener('click', clickHandler);
+    e.tabIndex = 0;
+    e.removeAttribute('data-disabled');
+  });
+  document.removeEventListener('turbolinks:load', onLoadHandler);
+  document.removeEventListener('turbolinks:before-cache', onBeforeCacheHandler);
+};
 
-document.addEventListener('turbolinks:load', onLoadHandler)
-document.addEventListener('turbolinks:before-cache', onBeforeCacheHandler)
+document.addEventListener('turbolinks:load', onLoadHandler);
+document.addEventListener('turbolinks:before-cache', onBeforeCacheHandler);

--- a/app/javascript/feedbacks.js
+++ b/app/javascript/feedbacks.js
@@ -1,0 +1,27 @@
+const clickHandler = () => {
+    // If one of the feedback buttons are clicked, disable **ALL**
+    // those buttons (which are actually <a> elements).
+    document.querySelectorAll('.feedback-button').forEach((e) => {
+        e.tabIndex = -1
+        e.setAttribute('data-disabled', 'disabled')
+    })
+}
+
+const onLoadHandler = () => {
+    document.querySelectorAll('.feedback-button').forEach((e) => {
+        e.addEventListener('click', clickHandler)
+    })
+}
+
+const onBeforeCacheHandler = () => {
+    document.querySelectorAll('.feedback-button').forEach((e) => {
+        e.removeEventListener('click', clickHandler)
+        e.tabIndex = 0
+        e.removeAttribute('data-disabled')
+    })
+    document.removeEventListener('turbolinks:load', onLoadHandler)
+    document.removeEventListener('turbolinks:before-cache', onBeforeCacheHandler)
+}
+
+document.addEventListener('turbolinks:load', onLoadHandler)
+document.addEventListener('turbolinks:before-cache', onBeforeCacheHandler)

--- a/app/javascript/feedbacks.js
+++ b/app/javascript/feedbacks.js
@@ -1,4 +1,4 @@
-const clickHandler = () => {
+const feedbackButtonClickHandler = () => {
   // If one of the feedback buttons are clicked, disable **ALL**
   // those buttons (which are actually <a> elements).
   document.querySelectorAll('.feedback-button').forEach(e => {
@@ -9,13 +9,13 @@ const clickHandler = () => {
 
 const onLoadHandler = () => {
   document.querySelectorAll('.feedback-button').forEach(e => {
-    e.addEventListener('click', clickHandler);
+    e.addEventListener('click', feedbackButtonClickHandler);
   });
 };
 
 const onBeforeCacheHandler = () => {
   document.querySelectorAll('.feedback-button').forEach(e => {
-    e.removeEventListener('click', clickHandler);
+    e.removeEventListener('click', feedbackButtonClickHandler);
     e.tabIndex = 0;
     e.removeAttribute('data-disabled');
   });

--- a/app/javascript/feedbacks.js
+++ b/app/javascript/feedbacks.js
@@ -8,11 +8,13 @@ function enable(link) {
   link.removeAttribute('data-disabled');
 }
 
-
 const feedbackButtonClickHandler = () => {
   // If one of the feedback buttons are clicked, disable **ALL**
   // those buttons (which are actually <a> elements).
   document.querySelectorAll('.feedback-button').forEach(disable);
+  window.setTimeout(() => {
+    document.querySelectorAll('.feedback-button').forEach(enable);
+  }, 2000);
 };
 
 const onLoadHandler = () => {

--- a/app/javascript/feedbacks.js
+++ b/app/javascript/feedbacks.js
@@ -1,10 +1,18 @@
+function disable(link) {
+  link.tabIndex = -1;
+  link.setAttribute('data-disabled', 'disabled');
+}
+
+function enable(link) {
+  link.tabIndex = 0;
+  link.removeAttribute('data-disabled');
+}
+
+
 const feedbackButtonClickHandler = () => {
   // If one of the feedback buttons are clicked, disable **ALL**
   // those buttons (which are actually <a> elements).
-  document.querySelectorAll('.feedback-button').forEach(e => {
-    e.tabIndex = -1;
-    e.setAttribute('data-disabled', 'disabled');
-  });
+  document.querySelectorAll('.feedback-button').forEach(disable);
 };
 
 const onLoadHandler = () => {
@@ -16,8 +24,7 @@ const onLoadHandler = () => {
 const onBeforeCacheHandler = () => {
   document.querySelectorAll('.feedback-button').forEach(e => {
     e.removeEventListener('click', feedbackButtonClickHandler);
-    e.tabIndex = 0;
-    e.removeAttribute('data-disabled');
+    enable(e);
   });
   document.removeEventListener('turbolinks:load', onLoadHandler);
   document.removeEventListener('turbolinks:before-cache', onBeforeCacheHandler);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -37,6 +37,7 @@ import '../user_site_settings';
 import '../graphs';
 import '../site_settings';
 import '../comments';
+import '../feedbacks';
 
 import { onLoad, installSelectpickers, uuid4, hashCode } from '../util';
 


### PR DESCRIPTION
Disable all feedback buttons once one of them is clicked.

There are some strange race conditions on the backend which
results in one user being able to have two or more active
(i.e. not invalidated) feedbacks on the same post, regardless
how many before_save, after_save and after_commit hooks
we run.

Ideally this should be fixed by a database trigger but
in the mean time this change prevents accidental creation
of multiple feedbacks.

Note that this change will NOT prevent intentional creation
of multiple feedbacks, as users can just call APIs directly,
circumventing restrictions implemented using javascript.