### PR TITLE
URGENT: Upgrade mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.2)


### PR DESCRIPTION
Upgrade mimemagic to mitigate licensing concerns.

Mimemagic <= 0.3.5 contains a copy of freedesktop.org.xml, which is under GPL license.
Due to licensing concerns, those versions are now yanked from RubyGems.org.

This project is licensed under CC0, which GPL is not compatible with.

This PR upgrades Mimemagic to 0.3.10, which does not have these problems.

Package `shared-mime-info` needs to be installed on the target system. This package is already installed on most Linuxes.

closes #849