### PR TITLE
Remove obsolete version of after_sign_in_path_for

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,22 +29,6 @@ class ApplicationController < ActionController::Base
     raise ActionController::RoutingError, 'Not Found'
   end
 
-  def after_sign_in_path_for(resource_or_scope)
-    if current_user.username.nil?
-      users_username_path
-    elsif current_user.stack_exchange_account_id.nil?
-      authentication_status_path
-    else
-      stored_location = nil
-      begin
-        stored_location = stored_location_for(resource_or_scope)
-      rescue # rubocop:disable Lint/HandleExceptions
-      end
-
-      request.env['omniauth.origin'] || stored_location || root_path
-    end
-  end
-
   def redis_log(_msg)
     # redis = redis(logger: true)
     # redis.multi do |m|


### PR DESCRIPTION
In PR #852 there is an `after_sign_in_path_for` method added to ApplicationController. However, there is already an existing method with the same name, causing Rubocop to complain. This PR removes the old method.