### PR TITLE
Dockerfile: optionally import dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.7
 
+# To import a recent dump from metasmoke, copy the downloaded files
+# to a directory named import in the current directory before building.
+# Caution: The import took me over ten minutes on a MacBook Pro 2018
+
 ######## FIXME: hardcoded password "password" everywhere
 
 # The base image ruby:2.7 is Debian Bullseye

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ FROM ruby:2.7
 RUN apt-get update
 # allow mariadb server to start, see comment in policy-rd.d
 RUN sed -i~ 's/^exit 101/exit 0/' /usr/sbin/policy-rc.d
-RUN apt-get install -y mariadb-server mariadb-client \
-       nodejs yarnpkg libpcre3-dev
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y mariadb-server mariadb-client \
+       nodejs yarnpkg libpcre3-dev tzdata
 
 # Debian stupidly reserves yarn for a different package
 # https://bugs.debian.org/940511

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ to this.
 ## Docker
 There is a simple `Dockerfile` here which is however not properly tested yet.
 
+If you want to include a database dump, create a directory `import`
+and place the dump files there (one `*.rdb.gz` and one `*.sql.gz`).
+This will noticeably slow down the build (plan 10-15 minutes,
+depending also on disk speed and hardware).
+
 To create a local build, simply
 
     docker build -t metasmoke .

--- a/createdb
+++ b/createdb
@@ -2,6 +2,20 @@
 
 set -e -u
 
+if [ -d import ]; then
+    for redis in import/*.rdb.gz; do
+        if [ -e "$redis" ]; then
+            echo "$0: importing $redis" >&2
+            gzip -dc "$redis" >dump.rdb
+            chmod 644 dump.rdb
+            # chown redis:redis dump.rdb
+        else
+            echo "$0: No files matching $redis" >&2
+            exit 124
+        fi
+    done
+fi
+
 ./services
 
 mysql -u root -ppassword <<\____
@@ -21,8 +35,7 @@ mysql -u root -ppassword <<\____
     GRANT ALL PRIVILEGES ON `metasmoke`.* TO `metasmoke`@`localhost`;
     GRANT ALL PRIVILEGES ON `metasmoke_test`.* TO `metasmoke`@`localhost`;
     GRANT ALL PRIVILEGES ON `metasmoke_production`.* TO `metasmoke`@`localhost`;
-    FLUSH PRIVILEGES; 
-
+    FLUSH PRIVILEGES;
 ____
 
 sed '/^development:/!b;x;N;N;x;a\
@@ -43,8 +56,23 @@ rails db:schema:load
 rails db:migrate
 # rails db:seed
 
-######## FIXME: yet another hard-coded, easily guessable password
-rails c <<\____
+if [ -d import ]; then
+    for sql in import/*.sql.gz; do
+        if [ -e "$sql" ]; then
+            echo "$0: importing $sql (this takes a long time)" >&2
+            ######## FIXME: yet another hard-coded, easily guessable password
+            gzip -dc <"$sql" |
+            sed 's/dump_metasmoke/metasmoke/g' |
+            mysql -u root -ppassword metasmoke
+        else
+            echo "$0: No files matching $sql" >&2
+            exit 123
+        fi
+        break
+    done
+else
+    ######## FIXME: yet another hard-coded, easily guessable password
+    rails c <<\____
 u = User.create(
   username: 'metasmoke', email: 'metasmoke@localhost', password: 'password')
 u.add_role(:admin)
@@ -52,3 +80,4 @@ u.add_role(:developer)
 
 SiteSetting.create(name: 'registration_enabled', value: 1)
 ____
+fi

--- a/createdb
+++ b/createdb
@@ -38,6 +38,8 @@ mysql -u root -ppassword <<\____
     FLUSH PRIVILEGES;
 ____
 
+mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
+
 sed '/^development:/!b;x;N;N;x;a\
   adapter: mysql2\
   database: metasmoke\


### PR DESCRIPTION
This implements a simple extension to include a database dump at `docker build` time.