### PR TITLE
Use a single database query to get domain total/TP/FP/NAA counts

### DIFF
--- a/app/views/spam_domains/_domain.html.erb
+++ b/app/views/spam_domains/_domain.html.erb
@@ -1,6 +1,6 @@
 <% post_id ||= nil %>
 <%
-counts_summary = PostSpamDomain.joins(:posts)
+counts_summary = PostSpamDomain.joins(:post)
                                .where(posts_spam_domains: {spam_domain_id: domain.id})
                                .select('COUNT(*) as total, SUM(is_tp) as tp, SUM(is_fp) as fp, SUM(is_naa) as naa')
                                .first

--- a/app/views/spam_domains/_domain.html.erb
+++ b/app/views/spam_domains/_domain.html.erb
@@ -1,12 +1,13 @@
 <% post_id ||= nil %>
 <%
-counts_summary = %i[all tp fp naa].map do |t|
-        [t, Post.joins(spam_domains: :domain_tags).where(spam_domains: {id: domain.id}).where.not(id: post_id).distinct.send(t).count]
-      end.to_h
+counts_summary = PostSpamDomain.joins(:posts)
+                               .where(posts_spam_domains: {spam_domain_id: domain.id})
+                               .select('COUNT(*) as total, SUM(is_tp) as tp, SUM(is_fp) as fp, SUM(is_naa) as naa')
+                               .first
 occurances ||= false
 %>
 <span class="spam-domain">
-  <% if occurances && counts_summary[:all] > 0 %>
+  <% if occurances && counts_summary[:total] > 0 %>
     <% if counts_summary[:tp] == 0 %>
       <span class="text-danger">✗</span>
     <% end %>


### PR DESCRIPTION
As of yet, this is untested. It's based on [answer to: "consolidating multiple column counts into a single query with Rails 4 Activerecord"](https://stackoverflow.com/a/27494947/3773011). The intent is to get all of the domain's total/TP/FP/NAA counts in a single query which doesn't depend on the current post (so it can be cached).

Issue: The current code:
```
counts_summary = %i[all tp fp naa].map do |t|
        [t, Post.joins(spam_domains: :domain_tags).where(spam_domains: {id: domain.id}).where.not(id: post_id).distinct.send(t).count]
      end.to_h
```

ends up being translated to the following 4 queries, all of which take a significant amount of time:

```
SELECT COUNT(DISTINCT `posts`.`id`) FROM `posts` INNER JOIN `posts_spam_domains` ON `posts_spam_domains`.`post_id` = `posts`.`id` INNER JOIN `spam_domains` ON `spam_domains`.`id` = `posts_spam_domains`.`spam_domain_id` INNER JOIN `domain_tags_spam_domains` ON `domain_tags_spam_domains`.`spam_domain_id` = `spam_domains`.`id` INNER JOIN `domain_tags` ON `domain_tags`.`id` = `domain_tags_spam_domains`.`domain_tag_id` WHERE `spam_domains`.`id` = 3 AND `posts`.`id` != 333688;
SELECT COUNT(DISTINCT `posts`.`id`) FROM `posts` INNER JOIN `posts_spam_domains` ON `posts_spam_domains`.`post_id` = `posts`.`id` INNER JOIN `spam_domains` ON `spam_domains`.`id` = `posts_spam_domains`.`spam_domain_id` INNER JOIN `domain_tags_spam_domains` ON `domain_tags_spam_domains`.`spam_domain_id` = `spam_domains`.`id` INNER JOIN `domain_tags` ON `domain_tags`.`id` = `domain_tags_spam_domains`.`domain_tag_id` WHERE `spam_domains`.`id` = 3 AND `posts`.`id` != 333688 AND `posts`.`is_tp` = TRUE;
SELECT COUNT(DISTINCT `posts`.`id`) FROM `posts` INNER JOIN `posts_spam_domains` ON `posts_spam_domains`.`post_id` = `posts`.`id` INNER JOIN `spam_domains` ON `spam_domains`.`id` = `posts_spam_domains`.`spam_domain_id` INNER JOIN `domain_tags_spam_domains` ON `domain_tags_spam_domains`.`spam_domain_id` = `spam_domains`.`id` INNER JOIN `domain_tags` ON `domain_tags`.`id` = `domain_tags_spam_domains`.`domain_tag_id` WHERE `spam_domains`.`id` = 3 AND `posts`.`id` != 333688 AND `posts`.`is_fp` = TRUE;
SELECT COUNT(DISTINCT `posts`.`id`) FROM `posts` INNER JOIN `posts_spam_domains` ON `posts_spam_domains`.`post_id` = `posts`.`id` INNER JOIN `spam_domains` ON `spam_domains`.`id` = `posts_spam_domains`.`spam_domain_id` INNER JOIN `domain_tags_spam_domains` ON `domain_tags_spam_domains`.`spam_domain_id` = `spam_domains`.`id` INNER JOIN `domain_tags` ON `domain_tags`.`id` = `domain_tags_spam_domains`.`domain_tag_id` WHERE `spam_domains`.`id` = 3 AND `posts`.`id` != 333688 AND `posts`.`is_naa` = TRUE; 
```
Those queries can take, in a total, on the order of tens of seconds, sometimes > 1 minute. In the following example (also used for the example queries above), it's > 20 seconds:
[![Four queries ](https://i.stack.imgur.com/hLAmo.png)](https://i.stack.imgur.com/hLAmo.png)


The code is changed to (based on [this answer](https://stackoverflow.com/a/27494947/3773011)):
```
counts_summary = PostSpamDomain.joins(:posts)
                               .where(posts_spam_domains: {spam_domain_id: domain.id})
                               .select('COUNT(*) as total, SUM(is_tp) as tp, SUM(is_fp) as fp, SUM(is_naa) as naa')
                               .first
```
The query I'm attempting to duplicate is the following, which [works well in Blazer, the SQL Data Explorer](https://metasmoke.erwaysoftware.com/data/sql/queries/283-domain-total-tp-fp-naa-count-by-domain-id?spam_domain_id=3):
```
SELECT COUNT(*) as total, SUM(is_tp) as tp, SUM(is_fp) as fp, SUM(is_naa) as naa FROM `p_posts_spam_domains` 
    INNER JOIN `p_posts` ON `p_posts_spam_domains`.`post_id` = `p_posts`.`id`
    WHERE `p_posts_spam_domains`.`spam_domain_id` = {spam_domain_id}
```

This does rely on `SUM()` over `is_tp`, `is_fp`, and `is_naa`, rather than counting based on a test for a "true" value, so could be disrupted if we're not using 1 to indicate true in some instances.

#### This does make a functional change (i.e. different data is returned)
This change does, however, return different results. The original code removes the current post from the counts. I have some problems with that.
1. I find it very confusing to be presented with different numbers for the domain which vary based on the post I'm currently viewing.
2. The current approach pushes not counting the current post into the database query. This makes the query unique to each post, which can't be cached for reuse when viewing multiple posts with the same domain.
3. If we do want to remove the current post from the counts, then we should do so using the Post data for the current post, which we already have (i.e. in code, not in the database query).




