### PR TITLE
Spam domain API fix

### DIFF
--- a/app/api/api/posts_api.rb
+++ b/app/api/api/posts_api.rb
@@ -83,10 +83,13 @@ module API
       std_result Post.where(deleted_at: nil).order(id: :desc), filter: FILTERS[:posts]
     end
 
-    # We are not using "get 'uid/:api_param/:native_id' do", because that does not permit a literal '.' in the api param,
-    # which is required for meta and localized SO sites.
-    get 'uid/(*api_param)/(*native_id)' do
-      std_result Post.joins(:site).where(sites: { api_parameter: params[:api_param] }, posts: { native_id: params[:native_id] }),
+    get 'uid/:api_param/:native_id' do
+      # Newer versions of Ruby drop everything after the first dot
+      # Parse the raw request to get the actual query string
+      # request.env['PATH_INFO'] is '/v2.0/uid/foo.bar/1234'
+      tail = request.env['PATH_INFO'].split(/[?&]/, 2)[0].split('/uid/', 2)[1]
+      values = tail.split('/', 2)
+      std_result Post.joins(:site).where(sites: { api_parameter: values[0] }, posts: { native_id: values[1] }),
                  filter: FILTERS[:posts]
     end
 

--- a/app/api/api/spam_domains_api.rb
+++ b/app/api/api/spam_domains_api.rb
@@ -10,8 +10,7 @@ module API
       # Newer versions of Ruby drop everything after the first dot
       # Parse the raw request to get the actual query string
       # request.env['PATH_INFO'] is '/v2.0/domains/name/test.spam.com'
-      name = request.env['PATH_INFO'].split(
-        '/domains/name/', 2)[1].split(/[?&]/, 2)[0]
+      name = request.env['PATH_INFO'].split('/domains/name/', 2)[1].split(/[?&]/, 2)[0]
       std_result SpamDomain.where(domain: name).order(id: :desc), filter: FILTERS[:domains]
     end
 

--- a/app/api/api/spam_domains_api.rb
+++ b/app/api/api/spam_domains_api.rb
@@ -6,9 +6,13 @@ module API
       std_result SpamDomain.all.order(id: :desc), filter: FILTERS[:domains]
     end
 
-    # We are not using name/:name, because otherwise it will not allow literal '.' in :name
-    get 'name/(*name)' do
-      std_result SpamDomain.where(domain: params[:name]).order(id: :desc), filter: FILTERS[:domains]
+    get 'name/:name' do
+      # Newer versions of Ruby drop everything after the first dot
+      # Parse the raw request to get the actual query string
+      # request.env['PATH_INFO'] is '/v2.0/domains/name/test.spam.com'
+      name = request.env['PATH_INFO'].split(
+        '/domains/name/', 2)[1].split(/[?&]/, 2)[0]
+      std_result SpamDomain.where(domain: name).order(id: :desc), filter: FILTERS[:domains]
     end
 
     get ':id/posts' do


### PR DESCRIPTION
As suggested by @user12986714, parse out the argument from `request.env['PATH_INFO']` in the `name/:name` for `spam_domains` and posts `uid/:api_param/:native_id` for `posts` routes.