### PR TITLE
Gemfile: pin GraphQL to 1.12.16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,4 +117,4 @@ group :test do
 end
 
 gem 'graphiql-rails'
-gem 'graphql', '< 2.0.0'
+gem 'graphql', '= 1.12.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.554.0)
-    aws-sdk-core (3.126.0)
+    aws-sdk-core (3.126.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -216,7 +216,7 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (1.13.9)
+    graphql (1.12.16)
     groupdate (5.0.0)
       activesupport (>= 5)
     hashdiff (1.0.1)
@@ -225,12 +225,12 @@ GEM
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.9.1)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jmespath (1.5.0)
+    jmespath (1.6.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -379,7 +379,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
+    simplecov_json_formatter (0.1.4)
     spring (4.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -465,7 +465,7 @@ DEPENDENCIES
   foreman
   grape (= 1.3.0)
   graphiql-rails
-  graphql (< 2.0.0)
+  graphql (= 1.12.16)
   groupdate (~> 5.0.0)
   htmlentities (~> 4.3, >= 4.3.4)
   httparty


### PR DESCRIPTION
Gemfile.lock: regenerated

Latest update broke GraphQL by bringing it to 1.13.x; roll this back for now.