### PR TITLE
Increase maximum spam wave duration to 48 hours

### DIFF
--- a/app/controllers/spam_waves_controller.rb
+++ b/app/controllers/spam_waves_controller.rb
@@ -59,8 +59,8 @@ class SpamWavesController < ApplicationController
   end
 
   def renew
-    @wave.update(expiry: 24.hours.from_now)
-    flash[:success] = 'Renewed wave for 24 hours.'
+    @wave.update(expiry: 48.hours.from_now)
+    flash[:success] = 'Renewed wave for 48 hours.'
     redirect_back fallback_location: spam_wave_path(@wave)
   end
 

--- a/app/models/spam_wave.rb
+++ b/app/models/spam_wave.rb
@@ -58,7 +58,7 @@ class SpamWave < ApplicationRecord
   end
 
   def max_expiry
-    return if expiry <= 1.day.from_now
-    errors.add(:expiry, 'must be no more than 24 hours from now')
+    return if expiry <= 2.day.from_now
+    errors.add(:expiry, 'must be no more than 48 hours from now')
   end
 end

--- a/app/views/spam_waves/_form.html.erb
+++ b/app/views/spam_waves/_form.html.erb
@@ -39,7 +39,7 @@
             <%= label_tag :expiry %><br/>
             <%= datetime_field_tag :expiry, default(:expiry, wave, 24.hours.from_now)&.to_datetime&.iso8601[0..-2], class: 'form-control' %>
             <span class="help-block">
-              <%= help_or_error(:expiry, "A point after which this wave will be deactivated. Maximum 24 hours from now.") %>
+              <%= help_or_error(:expiry, "A point after which this wave will be deactivated. Maximum 48 hours from now. Default 24 hours from now.") %>
             </span>
           </div>
 

--- a/app/views/spam_waves/_form.html.erb
+++ b/app/views/spam_waves/_form.html.erb
@@ -49,7 +49,7 @@
           <div class="field form-group">
             <% h = HTMLEntities.new %>
             <%= label_tag :sites %><br/>
-            <%= select_tag :sites, options_for_select(Site.mains.map{ |s| [h.decode(s.site_name), s.id] }, selected: wave&.sites&.map(&:id)),
+            <%= select_tag :sites, options_for_select(Site.select(:site_name, :id).all.order(:site_name).map{ |s| [h.decode(s.site_name), s.id] }, selected: wave&.sites&.map(&:id)),
                            multiple: true, class: 'form-control selectpicker', 'data-live-search' => true, 'data-actions-box' => true,
                            'data-dropup-auto' => false %>
             <span class="help-block">Choose the sites this wave should apply to.</span>

--- a/app/views/spam_waves/_spam_wave.html.erb
+++ b/app/views/spam_waves/_spam_wave.html.erb
@@ -1,10 +1,17 @@
 <div class="spam-wave" data-id="<%= wave.id %>">
   <h3><%= link_to wave.name, spam_wave_path(wave) %></h3>
-  <p class="text-muted">Created by <%= wave.user.username %> <%= time_ago_in_words(wave.created_at) %> ago.</p>
+  <p class="text-muted">Created by <%= wave.user.username %> <span title="<%= wave.created_at %>"><%= time_ago_in_words(wave.created_at) %></span> ago.</p>
   <% if wave.expiry.past? %>
-    <p>Expired.</p>
+    <p title="<%= wave.expiry %>">Expired.</p>
   <% else %>
-    <p>Expires in <%= distance_of_time_in_words(DateTime.now, wave.expiry) %>.</p>
+    <p>Expires in <span title="<%= wave.expiry %>"><%= distance_of_time_in_words(DateTime.now, wave.expiry) %></span>.</p>
   <% end %>
+  <span class="button-container">
+    <%= link_to 'Edit', edit_spam_wave_path(@wave), class: 'btn btn-primary' %>
+    <%= link_to 'Renew Wave', renew_spam_wave_path(@wave), class: 'btn btn-warning', method: :post %>
+    <% if wave.expiry.past? %>
+      <%= link_to 'Cancel Wave', cancel_spam_wave_path(@wave), class: 'btn btn-danger', method: :post %>
+    <% end %>
+  </span>
 </div>
 <hr/>

--- a/app/views/spam_waves/index.html.erb
+++ b/app/views/spam_waves/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Spam waves</h1>
 <p>Spam waves are a way to make it easy for us to respond to sudden influxes of a certain type of spam. By adding a wave here, everything matching
-the conditions specified will be autoflagged for 24 hours. Make sure you communicate what's being done to site mods or CM's.</p>
+the conditions specified will be autoflagged for up to 48 hours (default 24 hours). Make sure you communicate what's being done to site mods or CM's.</p>
 <p>
   <%= link_to new_spam_wave_path, class: 'btn btn-primary btn-sm' do %>
     <i class="fas fa-plus"></i> Create New

--- a/app/views/spam_waves/show.html.erb
+++ b/app/views/spam_waves/show.html.erb
@@ -1,17 +1,17 @@
 <h1><%= @wave.name %></h1>
 <h4 class="text-muted">Currently <strong><%= @wave.expiry.past? ? 'expired' : 'active' %>.</strong></h4>
-<p class="text-muted">Created by <%= @wave.user.username %> <%= time_ago_in_words(@wave.created_at) %> ago.</p>
+<p class="text-muted">Created by <%= @wave.user.username %> <span title="<%= wave.created_at %>"><%= time_ago_in_words(@wave.created_at) %> ago</span>.</p>
 
-<% unless @wave.expiry.past? %>
-  <p>Expires in <%= distance_of_time_in_words(DateTime.now, @wave.expiry) %>.</p>
+<% if @wave.expiry.past? %>
+  <p>Expired <span title="<%= @wave.expiry %>"><%= distance_of_time_in_words(DateTime.now, @wave.expiry) %> ago</span>.</p>
+<% else %>
+  <p>Expires in <span title="<%= @wave.expiry %>"><%= distance_of_time_in_words(DateTime.now, @wave.expiry) %></span>.</p>
 <% end %>
 
+<%= link_to 'Edit', edit_spam_wave_path(@wave), class: 'btn btn-primary' %>
+<%= link_to 'Renew Wave', renew_spam_wave_path(@wave), class: 'btn btn-warning', method: :post %>
 <% unless @wave.expiry.past? %>
-  <%= link_to 'Edit', edit_spam_wave_path(@wave), class: 'btn btn-primary' %>
   <%= link_to 'Cancel Wave', cancel_spam_wave_path(@wave), class: 'btn btn-danger', method: :post %>
-<% end %>
-<% if (@wave.expiry - DateTime.now) <= 2.hours && !@wave.expiry.past? %>
-  <%= link_to 'Renew Wave', renew_spam_wave_path(@wave), class: 'btn btn-warning', method: :post %>
 <% end %>
 
 <h3>Conditions</h3>


### PR DESCRIPTION
This PR:

* Increases the maximum duration of a spam wave to 48 hours, while leaving the default length at 24 hours.
* Allows selecting meta sites for spam waves, in addition to main sites. This is something which would have been useful earlier today.
* Added tooltips with the created/expired date/time stamps.
* Added "Edit", "Renew", and "Cancel" buttons to the spam wave list and adjusted them in the individual spam wave pages.