### PR TITLE
add domain link: Prevent double add and fix modal operation.

### DIFF
--- a/app/javascript/domain_links.js
+++ b/app/javascript/domain_links.js
@@ -1,8 +1,4 @@
-import { onLoad } from './util';
-
-onLoad(() => {
-  $('.domain-link-form').on('ajax:success', (ev, data) => {
-    $('.domain-links-list').append(data);
-    $(ev.target).parents('.modal').modal('close');
-  });
+$(document).on('ajax:success', '#new_domain_link', (ev, data) => {
+  $('.domain-links-list').append(data);
+  $(ev.target).parents('.modal').modal('hide');
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -118,7 +118,9 @@ const metasmoke = window.metasmoke = {
     initFormParamCleanups: () => {
       const formParameterCleanups = [];
 
-      $(document.body).on('submit', 'form', ev => {
+      // This excludes data-remote, because other JavaScript creates the POST, so this code
+      // results in a duplicated POST being sent.
+      $(document.body).on('submit', 'form:not([data-remote="true"])', ev => {
         const tgt = $(ev.target);
         if (formParameterCleanups.indexOf(tgt[0]) === -1) {
           ev.preventDefault();


### PR DESCRIPTION
This partially resolves #775 and #779.

It should fix the "New Domain Link" modal such that it only adds one domain link, inserts the data about the added domain link into the domain page and then closes the modal.