### PR TITLE
Remove duplicated dropdown selection dialogs.

### DIFF
--- a/app/javascript/general_fixes.js
+++ b/app/javascript/general_fixes.js
@@ -1,0 +1,11 @@
+import { onLoad } from './util';
+
+onLoad(() => {
+  // This is a patch to remove duplicated dropdown selections.
+  // It would be better to prevent these from being created.
+  $('.dropdown.bootstrap-select > .dropdown.bootstrap-select').each(function () {
+    const useSelect = $(this);
+    useSelect.parent().replaceWith(useSelect);
+  });
+});
+

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -38,6 +38,7 @@ import '../graphs';
 import '../site_settings';
 import '../comments';
 import '../spam_waves';
+import '../general_fixes';
 
 import { onLoad, installSelectpickers, uuid4, hashCode } from '../util';
 


### PR DESCRIPTION
Resolves #892

This is a hack to remove the duplicated selection dialogs which are created when the forward and back buttons are used to navigate pages. It would be better to prevent the dialogs from being created, but this appears to be sufficient for now.

This also creates and imports the general_fixes.js file.