### PR TITLE
Prevent quick duplicate/similar AJAX requests.

### DIFF
--- a/app/javascript/general_fixes.js
+++ b/app/javascript/general_fixes.js
@@ -14,3 +14,36 @@ setTimeout(() => {
     });
   });
 }, 100);
+
+(() => {
+  /* This prevents multiple requests being made to the same URL within a short period of time.
+   *   It should affect anywhere where more than one request of the same type is being made to
+   *   the same URL within 100ms.
+   */
+  const minimumTimeBetweenBackToBackRequests = 100;
+  const dupAjaxRequestIgnoredUrls = [
+    'https://metasmoke.erwaysoftware.com/mini-profiler-resources/results',
+    '/mini-profiler-resources/results'
+  ];
+  const priorAjaxSendInfo = {
+    url: '',
+    date: 0,
+    type: ''
+  };
+
+  function dontPermitQuickBackToBackRequestsToSameURL(event, jqXHR, requestSettings) {
+    const now = Date.now();
+    if (!dupAjaxRequestIgnoredUrls.includes(requestSettings.url)) {
+      if (priorAjaxSendInfo.date > (now - minimumTimeBetweenBackToBackRequests) && priorAjaxSendInfo.url === requestSettings.url && priorAjaxSendInfo.type === requestSettings.type) {
+        // Abort this request which is to the same URL and within 100ms of the most recent prior request.
+        console.error('Aborting rapid request to same url:\nTHIS MAY CONTAIN PRIVATE INFORMATION. Be careful when sharing.\nrequestSettings.url:', requestSettings.url, '::  requestSettings:', requestSettings, '::  jqXHR:', jqXHR, '::  event:', event); // eslint-disable-line no-console
+        jqXHR.abort();
+        return;
+      }
+    }
+    priorAjaxSendInfo.date = now;
+    priorAjaxSendInfo.url = requestSettings.url;
+    priorAjaxSendInfo.type = requestSettings.type;
+  }
+  $(document).ajaxSend(dontPermitQuickBackToBackRequestsToSameURL);
+})();


### PR DESCRIPTION
There are several situations, both programmatic and via user input, where we're experiencing the effects of having duplicate requests being sent causing unexpected operation. The one which was clearest to me was the add new domain link dialog where two links were always created. While this change also prevented that duplication, that specific duplication was resolved specific to using data-remote in a `<form>` in #935.

This should effectively resolve the portion of #775 which is the result of things being double-acted from the MS user interface. It's not clear to me at this time how the [duplicate domains were created](https://metasmoke.erwaysoftware.com/data/sql/queries/42-duplicate-domain-tags-405), so I don't expect this to resolve that portion of #775.