### PR TITLE
In live bs-searchboxes, also search on input (i.e. paste).

### DIFF
--- a/app/javascript/util.js
+++ b/app/javascript/util.js
@@ -106,7 +106,7 @@ export function installSelectpickers() {
       noneResultsText: 'No results matched your search or you need to enter more characters to search with.'
     });
 
-    $(e).parent().find('.bs-searchbox input[type="search"]').on('keydown', ev => {
+    $(e).parent().find('.bs-searchbox input[type="search"]').on('keydown input', ev => {
       if ($(ev.target).val().length < 2) {
         return;
       }


### PR DESCRIPTION
This should resolve the titular issue in #941 of pasting a domain name in the new domain link dialog not triggering a search and fill of the available domains. It will also do the same for all other similar `data-remote-source` `search` boxes. It doesn't address any other concerns which are detailed in that issue.