### PR TITLE
Preparation for live post lists

### DIFF
--- a/app/views/dashboard/site_dash.html.erb
+++ b/app/views/dashboard/site_dash.html.erb
@@ -74,17 +74,17 @@
   </code>
 </div>
 
-<ul class="nav nav-tabs">
+<ul class="nav nav-tabs post-table-nav-tabs">
   <% @tabs.each do |tab, posts| %>
-  <li class="<%= "active" if tab.downcase == @active_tab %>">
+  <li class="nav-tab nav-tab-<%= tab.downcase %> <%= "active" if tab.downcase == @active_tab %>">
     <%= link_to "#{tab} (#{number_with_delimiter(posts.count, delimiter: @delimiter)})", site_dash_path(params.permit(:site_id, :months).to_h.merge(tab: tab.downcase)) %>
   </li>
   <% end %>
-  <li class="<%= "active" if @active_tab.downcase == "spammers" %>">
+  <li class="nav-tab nav-tab-spammers <%= "active" if @active_tab.downcase == "spammers" %>">
     <%= link_to "Spammers (#{number_with_delimiter(@spammers.length, delimiter: @delimiter)})", site_dash_path(params.permit(:site_id, :months).to_h.merge(tab: 'spammers')) %>
   </li>
   <% if user_signed_in? && (current_user.moderator_sites.exists? || current_user.has_role?(:admin)) %>
-    <li class="<%= "active" if @active_tab.downcase == "autoflaggers" %>">
+    <li class="nav-tab nav-tab-autoflaggers <%= "active" if @active_tab.downcase == "autoflaggers" %>">
       <%= link_to "Autoflaggers (#{number_with_delimiter(@autoflaggers.length, delimiter: @delimiter)})", site_dash_path(params.permit(:site_id, :months).to_h.merge(tab: 'autoflaggers')) %>
     </li>
   <% end %>
@@ -98,14 +98,14 @@
   <% if @posts.count == 0 %>
     <p>No spam here! Try another filter.</p>
   <% else %>
-    <table class="table">
+    <table class="table posts-table">
       <% @posts.each do |p| %>
         <%= render 'posts/post', post: p, deletion_date: true, show_autoflaggers: (user_signed_in? && current_user.moderator_sites.exists?), show_autoflagged: (user_signed_in? && current_user.moderator_sites.exists? && !%w[autoflagged].include?(@active_tab)) %>
       <% end %>
     </table>
   <% end %>
 
-  <div class="text-center">
+  <div class="text-center pagination-container">
     <%= will_paginate @posts, renderer: BootstrapPagination::Rails %>
   </div>
 <% end %>

--- a/app/views/dashboard/spam_by_site.html.erb
+++ b/app/views/dashboard/spam_by_site.html.erb
@@ -18,7 +18,7 @@
 <% if @posts.count == 0 %>
   <p>No spam here! Try another filter.</p>
 <% else %>
-  <table class="table">
+  <table class="table posts-table">
     <% @posts.each do |p| %>
       <%= render 'posts/post', post: p %>
     <% end %>

--- a/app/views/domain_tags/show.html.erb
+++ b/app/views/domain_tags/show.html.erb
@@ -29,7 +29,7 @@
 </ul>
 
 <% if params[:what] == 'domains' || params[:what].nil? %>
-  <table class="table table-striped">
+  <table class="table table-striped domains-table">
     <thead>
     <tr>
       <th>Domain</th>
@@ -68,7 +68,7 @@
 
   <%= will_paginate @domains, renderer: BootstrapPagination::Rails %>
 <% elsif params[:what] == 'posts' %>
-  <table class="table">
+  <table class="table posts-table">
     <tbody>
       <% @posts.each do |p| %>
         <%= render 'posts/post', post: p, wrap_in_tr: true %>
@@ -80,7 +80,7 @@
 <% end %>
 
 <% if current_user&.has_role?(:developer) %>
-  <div class="panel panel-danger">
+  <div class="panel panel-danger developer-tools searc-developer-tools">
     <div class="panel-heading">
       <h3 class="panel-title">Developer tools</h3>
     </div>

--- a/app/views/feedbacks/_feedback.html.erb
+++ b/app/views/feedbacks/_feedback.html.erb
@@ -1,3 +1,3 @@
-<span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-toggle="tooltip" data-placement="top"
+<span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top"
       title="<%= feedback.user.present? ? "#{feedback.user.try(:username)} (From Review)" : feedback.user_name %>: <%= feedback.feedback_type %>"
       class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>

--- a/app/views/feedbacks/_feedback.html.erb
+++ b/app/views/feedbacks/_feedback.html.erb
@@ -1,3 +1,3 @@
 <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top"
       title="<%= feedback.user.present? ? "#{feedback.user.try(:username)} (From Review)" : feedback.user_name %>: <%= feedback.feedback_type %>"
-      class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+      class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>

--- a/app/views/feedbacks/clear.html.erb
+++ b/app/views/feedbacks/clear.html.erb
@@ -1,6 +1,6 @@
 <h3>Clear Feedback</h3>
 
-<table class="table">
+<table class="table posts-table-single">
   <thead>
     <tr>
       <th>Post</th>

--- a/app/views/flag_conditions/_preview.html.erb
+++ b/app/views/flag_conditions/_preview.html.erb
@@ -13,7 +13,7 @@
   <br />
 
   <h4>Last 100 posts included</h4>
-  <table class="table">
+  <table class="table posts-table">
     <thead>
       <tr>
         <th>Post</th>

--- a/app/views/flag_log/not_flagged.html.erb
+++ b/app/views/flag_log/not_flagged.html.erb
@@ -1,7 +1,7 @@
 <h3>Unflagged posts</h3>
 <p>Solely posts which have <em>not</em> been automatically flagged.</p>
 
-<table class="table">
+<table class="table posts-table">
   <thead>
     <tr>
       <th>Post</th>

--- a/app/views/flag_settings/by_site.html.erb
+++ b/app/views/flag_settings/by_site.html.erb
@@ -20,7 +20,7 @@
   </p>
 
   <h4>Flagged Posts</h4>
-  <table class="table">
+  <table class="table posts-table">
     <% @posts.each do |p| %>
       <%= render 'posts/post', post: p %>
     <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,33 +8,33 @@
 <% @sites = [post.site] if @sites.nil? %>
 
 <% if wrap_in_tr %>
-<tr class="post-cell post-cell-<%= post.id %>">
+<tr class="post-cell post-cell-<%= post.id %> post-row">
 <% end %>
   <td>
     <% if post.try(:body).present? or post.try(:body_exists) == 1 %>
       <span class="text-muted show-post-body" data-postloaded="<%= preload_post_body.to_s %>" data-postid="<%= post.id %>"><%= (expand_post.present? and expand_post) ? "▼" : "►" %></span>
     <% end %>
 
-    <bdi><%= link_to post.title, "/post/" + post.id.to_s %></bdi>
+    <bdi class="post-title-bdi"><%= link_to post.title, "/post/" + post.id.to_s, class: 'post-title-link'  %></bdi>
 
     <% if show_autoflagged && post.flagged? %>
-      <span class="glyphicon glyphicon-flag text-danger" title="This post was autoflagged"></span>
+      <span class="glyphicon glyphicon-flag text-danger autoflagged-marker" title="This post was autoflagged"></span>
     <% end %>
 
     <% unless post.feedbacks.empty? or hide_feedbacks %>
-      <strong>
+      <strong class="feedbacks-container">
          <% post.feedbacks.each do |feedback| %>
-           <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? or feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+           <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? or feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>
          <% end %>
       </strong>
     <% end %>
 
-    <span class="text-muted">
+    <span class="text-muted post-weight">
       (<%= post.reasons.map(&:weight).reduce(:+) %>)
     </span>
 
     <% if deletion_date && post.deleted_at %>
-      <span class='text-danger'>(deleted <%= distance_of_time_in_words(post.created_at, post.deleted_at, include_seconds: true) %> after creation)</span>
+      <span class='text-danger post-deletion-date'>(deleted <%= distance_of_time_in_words(post.created_at, post.deleted_at, include_seconds: true) %> after creation)</span>
     <% end %>
 
     <% if post.comments.any? && !hide_feedbacks %>
@@ -43,23 +43,23 @@
       </span>
     <% end %>
 
-    <span class="text-muted post-row-right">
+    <span class="text-muted post-row-right post-creation-and-user-container">
       <% unless post.created_at.nil? %>
-        <%= link_to "", post_path(id: post.id), title: post.created_at, "data-livestamp": post.created_at.to_i, class: "text-muted" %>
+        <%= link_to "", post_path(id: post.id), title: post.created_at, "data-livestamp": post.created_at.to_i, class: "text-muted post-creation-date" %>
       <% end %>
 
       <% unless post.username.nil? || post.stack_exchange_user.nil? %>
-        by <bdi><%= link_to post.username, url_for(controller: :stack_exchange_users, action: :show, id: post.stack_exchange_user.id) %></bdi>
+        <span class="post-username-by-text">by ><bdi class="post-owner-username-bdi"><%= link_to post.username, url_for(controller: :stack_exchange_users, action: :show, id: post.stack_exchange_user.id), class: 'post-username-link' %></bdi>
       <% end %>
 
       <% if post.site.present? %>
-        <%= link_to (image_tag post.site.site_logo, size: "20"), post.link %>
+        <%= link_to (image_tag post.site.site_logo, size: "20"), post.link, class: 'post-site-link' %>
       <% end %>
     </span>
 
     <div class="post-body" data-postid="<%= post.id %>" style="<%= "display: none;" unless expand_post.present? and expand_post %>">
       <% if preload_post_body %>
-        <ul class="nav nav-tabs" role="tablist">
+        <ul class="nav nav-tabs body-view-nav-tabs" role="tablist">
           <li role="presentation" class="active">
             <a href="#post-body-tab-<%= post.id %>" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="text">Text</a>
           </li>
@@ -73,8 +73,8 @@
           </li>
         </ul><br/>
 
-        <div class="tab-content">
-          <div role="tabpanel" class="tab-pane active" id="post-body-tab-<%= post.id %>">
+        <div class="tab-content body-content-container">
+          <div role="tabpanel" class="tab-pane active post-body-panel-text" id="post-body-tab-<%= post.id %>">
             <% if post.try(:body).present? or post.try(:body_exists) == 1 %>
               <div>
                 <pre class="post-body-pre-block"><%= post.body %></pre>
@@ -94,11 +94,11 @@
             <% end %>
           </div>
           <% unless post.markdown.nil? %>
-            <div role="tabpanel" class="tab-pane" id="post-source-tab-<%= post.id %>">
+            <div role="tabpanel" class="tab-pane post-body-panel-markdown" id="post-source-tab-<%= post.id %>">
               <pre class="post-body-pre-block"><%= post.markdown %></pre>
             </div>
           <% end %>
-          <div role="tabpanel" class="tab-pane" id="preview-tab-<%= post.id %>">
+          <div role="tabpanel" class="tab-pane post-body-panel-preview" id="preview-tab-<%= post.id %>">
             <div class="panel panel-default">
               <div class="panel-body">
                 <%= safe_render_markdown(post.markdown || post.body, scrubber: Post.scrubber) %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -24,7 +24,7 @@
     <% unless post.feedbacks.empty? or hide_feedbacks %>
       <strong>
          <% post.feedbacks.each do |feedback| %>
-           <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? or feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+           <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? or feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
          <% end %>
       </strong>
     <% end %>

--- a/app/views/posts/_table.html.erb
+++ b/app/views/posts/_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table" id="posts-index-table">
+<table class="table posts-table" id="posts-index-table">
   <tbody>
     <%= render partial: 'posts/post', collection: posts, cached: proc { |i| i.cachebreak } %>
   </tbody>

--- a/app/views/posts/by_url.html.erb
+++ b/app/views/posts/by_url.html.erb
@@ -1,6 +1,6 @@
 <h3>Disambiguation</h3>
 
-<table class="table">
+<table class="table posts-table">
   <tbody>
     <% @posts.each do |post| %>
       <%= render partial: 'posts/post', locals: { post: post, wrap_in_tr: true } %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,7 +2,7 @@
 
 <h3><%= title 'Recent posts' %></h3>
 
-<ul class="nav nav-tabs">
+<ul class="nav nav-tabs post-table-nav-tabs">
   <li class="<%= "active" if params[:filter].nil? %>">
     <%= link_to "All", posts_path %>
   </li>
@@ -13,6 +13,6 @@
 
 <%= render 'table', posts: @posts %>
 
-<div class="text-center">
+<div class="text-center pagination-container">
   <%= will_paginate @posts, renderer: BootstrapPagination::Rails %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,7 @@
   <% unless @is_review_item %>
     <strong class="post-feedbacks">
        <% @post.feedbacks.each do |feedback| %>
-         <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+         <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
        <% end %>
     </strong>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,14 +1,14 @@
-<h4>
+<h4 class="post-title-header">
   <% if @post.flag_logs.auto.successful.any? %>
     <%= link_to post_flag_logs_path(@post), style: "text-decoration:none"  do %>
-      <span class="text-danger" title="This post had flags cast on it" href="#"><%= @post.flag_logs.auto.successful.first.flag_icon %></span>
+      <span class="text-danger autoflagged-marker" title="This post had flags cast on it" href="#"><%= @post.flag_logs.auto.successful.first.flag_icon %></span>
     <% end %>
   <% end %>
-  <bdi><%= title @post.title %></bdi>
+  <bdi class="post-title-bdi"><%= title @post.title %></bdi>
   <% unless @is_review_item %>
-    <strong class="post-feedbacks">
+    <strong class="post-feedbacks feedbacks-container">
        <% @post.feedbacks.each do |feedback| %>
-         <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %>"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+         <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>
        <% end %>
     </strong>
   <% end %>
@@ -20,20 +20,20 @@
   <% unless @post.feedbacks.empty? || @is_review_item %>
     <% if current_user.present? && (current_user.has_role?(:admin) || @post.feedbacks.where(user_id: current_user.id).exists?) %>
       <small>
-        &middot; <%= link_to "(clear)", clear_post_feedback_path(@post) %>
+        &middot; <%= link_to "(clear)", clear_post_feedback_path(@post), class: 'clear-link' %>
       </small>
     <% end %>
   <% end %>
 </h4>
 
 <% if user_signed_in? %>
-  <p><a href="#" data-toggle="modal" data-target="#admin-report-modal" class="text-warning">
+  <p class="admin-report-paragraph"><a href="#" data-toggle="modal" data-target="#admin-report-modal" class="text-warning admin-report-link">
     <span data-toggle="tooltip" title="Request admin attention on this post"><span class="glyphicon glyphicon-alert"></span> Something not right?</span>
   </a></p>
 <% end %>
 
 <% if user_signed_in? && current_user.has_role?(:reviewer) && !@is_review_item %>
-  <p>
+  <p class="add-feedback-paragraph">
     <strong>Add feedback:</strong>
     <%= link_to raw('&#x2713'), post_feedback_path(post_id: @post.id, feedback_type: 'tp'),
                 class: 'feedback-button on-post text-success', remote: true, method: :post, data: { post_id: @post.id } %>
@@ -68,10 +68,10 @@
   <% end %>
 </div>
 
-<hr/>
+<hr class="post-body-hr-separator"/>
 
 <% unless @post.body.nil? %>
-  <ul class="nav nav-tabs" role="tablist">
+  <ul class="nav nav-tabs body-view-nav-tabs" role="tablist">
     <li role="presentation" class="active">
       <a href="#post-body-tab" role="tab" data-toggle="tab" class="post-render-mode" data-render-mode="text">Text</a>
     </li>
@@ -86,15 +86,15 @@
   </ul><br/>
 
   <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" id="post-body-tab">
+    <div role="tabpanel" class="tab-pane active post-body-panel-text" id="post-body-tab">
       <pre class="post-body-pre-block"><%= @post.body %></pre>
     </div>
     <% unless @post.markdown.nil? %>
-      <div role="tabpanel" class="tab-pane" id="post-source-tab">
+      <div role="tabpanel" class="tab-pane post-body-panel-markdown" id="post-source-tab">
         <pre class="post-body-pre-block"><%= @post.markdown %></pre>
       </div>
     <% end %>
-    <div role="tabpanel" class="tab-pane" id="preview-tab">
+    <div role="tabpanel" class="tab-pane post-body-panel-preview" id="preview-tab">
       <div class="panel panel-default">
         <div class="panel-body">
           <%= safe_render_markdown(@post.markdown || @post.body, scrubber: Post.scrubber) %>
@@ -104,15 +104,15 @@
   </div>
 <% end %>
 
-<hr>
+<hr class="post-links-and-user-hr-separator"/>
 
 <% unless @post.link.nil? %>
   <% unless @post.site&.site_logo.nil? %>
     <%= image_tag @post.site.site_logo, size: "20" %>
   <% end %>
-  <%= link_to "View on site", @post.link %>
+  <%= link_to "View on site", @post.link, class: 'post-site-link' %>
   <% if @post.deleted_at %>
-    <span class="text-danger">
+    <span class="text-danger post-deleted-at-span">
       (deleted
         <span title="<%= (@post.deleted_at - @post.created_at).round(0) %> seconds">
           <%= distance_of_time_in_words(@post.created_at, @post.deleted_at, include_seconds: true) %>
@@ -123,58 +123,59 @@
 <% end %>
 
 <% unless @post.created_at.nil? %>
-  <span class="text-muted" style="float:right">
-    <span title="<%= @post.created_at %>">
+  <span class="text-muted report-created-at-span" style="float:right">
+    <span class="report-created-at-span" title="<%= @post.created_at %>">
       <%= "reported " + time_ago_in_words(@post.created_at).sub("about ", "") + " ago " %>
     </span>
     <% if @post.revision_count.to_i >= 2 %>
-      | edited <%= number_to_multiplicative_quantifier @post.revision_count - 1 %>
+      <span class="post-edited-span">| edited <span class="post-edit-count"><%= number_to_multiplicative_quantifier @post.revision_count - 1 %></span></span>
     <% end %>
     <% unless @post.user_link.nil? %>
-      | posted by
+      <span class="post-user-span">| posted by
       <% unless @post.site&.site_logo&.nil? %>
-        <%= link_to @post.user_link do %>
+        <%= link_to @post.user_link, class: 'user-se-site-link' do %>
           <% unless @post.site&.site_logo.nil? %>
             <%= image_tag @post.site.site_logo, size: "20" %>
           <% end %>
         <% end %>
       <% end %>
       <% if @post.stack_exchange_user_id.present? %>
-          <bdi><%= link_to @post.username, stack_exchange_user_path(@post.stack_exchange_user_id) %></bdi>
+          <bdi class="post-owner-username-bdi"><%= link_to @post.username, stack_exchange_user_path(@post.stack_exchange_user_id), class: 'post-username-link' %></bdi>
       <% end %>
       <% unless @post.user_reputation.nil? %>
-        (<%= @post.user_reputation %>)
+        <span class="user-reputation-span">(<span class="user-reputation"><%= @post.user_reputation %></span>)</span>
       <% end %>
+      </span>
     <% end %>
   </span>
 <% end %>
-<hr>
+<hr class="post-reasons-hr-separator"/>
 
-<p>Caught by:</p>
+<p class="caught-by">Caught by:</p>
 
-<ul>
+<ul class="reasons-list">
   <% @post.reasons.each do |reason| %>
-    <li>
+    <li class="reasons-list-item">
       <%= link_to reason.reason_name, reason_path(reason), title: reason.description, data: { toggle: 'tooltip' } %>
-      <span class="text-muted">(<%= reason.weight %>)</span>
+      <span class="text-muted reason-weight-span">(<span class="reason-weight"><%= reason.weight %></span>)</span>
     </li>
   <% end %>
 </ul>
 
 <% if @post.respond_to?(:reason_weight) && @post.reason_weight&.present? %>
-  <p class="text-muted">Reason weight: <%= @post.reason_weight %></p>
+  <p class="text-muted total-weight-paragraph">Reason weight: <span class="post-total-weight"><%= @post.reason_weight %></span></p>
 <% else %>
-  <p class="text-muted">Reason weight: <%= @post.reasons.map(&:weight).reduce(:+) %></p>
+  <p class="text-muted total-weight-paragraph">Reason weight: <span class="post-total-weight"><%= @post.reasons.map(&:weight).reduce(:+) %></span></p>
 <% end %>
 
 <% if @post.why.present? %>
-  <pre><%= render_links @post.why %></pre>
+  <pre class="post-why"><%= render_links @post.why %></pre>
 <% end %>
 
 <% if user_signed_in? && current_user.write_authenticated && current_user.flags_enabled && !@post.is_fp && !@post.deleted? && Time.now - (@post.created_at || 1.day.ago) <= 1.hour && current_user.has_role?(:reviewer) %>
-  <p>
+  <p class="spam-abusive-flagging-paragraph">
     <% %w[spam abusive].each do |flag_type| %>
-      <%= link_to url_for(controller: :posts, action: :cast_spam_flag, id: @post.id, flag_type: flag_type), method: :post, class: "text-danger flag-link" do %>
+      <%= link_to url_for(controller: :posts, action: :cast_spam_flag, id: @post.id, flag_type: flag_type), method: :post, class: ("text-danger flagging-link flagging-link-" + flag_type) do %>
         <span class="glyphicon glyphicon-flag"></span> <%= flag_type.capitalize %> flag
       <% end %>
     <% end %>
@@ -185,18 +186,18 @@
   <%= render 'abuse_reports/list', item: @post %>
 <% end %>
 
-<hr/>
+<hr class="post-contained-domains-hr-separator"/>
 
-<p>Contains domains:</p>
+<p class="post-contained-domains-paragraph">Contains domains:</p>
 <% if @post.spam_domains.any? %>
   <ul class="post-domain-list">
     <% @post.spam_domains.each do |d| %>
-      <li>
+      <li class="post-domain-line-item">
         <%= render 'spam_domains/domain', domain: d, occurances: true, post_id: @post.id %>
         <% if current_user&.has_role?(:core) && !(psd = PostSpamDomain.find_by(post: @post, spam_domain: d)).added_by.nil? %>
-          <%= link_to "remove domain", remove_post_domain_path(id: @post.id, domain_id: d.id), class: 'btn-sm btn-danger', method: :post %>
+          <%= link_to "remove domain", remove_post_domain_path(id: @post.id, domain_id: d.id), class: 'btn-sm btn-danger remove-domain-link', method: :post %>
           <% if current_user&.has_role?(:admin) %>
-            <i class="text-muted">(added by <%= psd.added_by.username %>, user_id: <%= psd.added_by.id %>)</i>
+            <i class="text-muted domain-added-by-italics">(added by <%= psd.added_by.username %>, user_id: <%= psd.added_by.id %>)</i>
           <% end %>
         <% end %>
       </li>
@@ -214,15 +215,17 @@
   <% end %>
 <% end %>
 <br/>
-<% @post.comments.each do |c| %>
-  <%= render 'post_comments/comment', comment: c, feedback: @post.feedbacks.to_a.select { |f| f.user_id == c.user_id }[0] %>
-<% end %>
+<div class="post-comments-container">
+  <% @post.comments.each do |c| %>
+    <%= render 'post_comments/comment', comment: c, feedback: @post.feedbacks.to_a.select { |f| f.user_id == c.user_id }[0] %>
+  <% end %>
+</div>
 
 <% if current_user&.has_role?(:reviewer) %>
-  <p><a href="javascript:void(0)" class="new-comment"><span class="glyphicon glyphicon-plus"></span> Add a comment</a></p>
+  <p class="add-new-comment-paragraph"><a href="javascript:void(0)" class="new-comment"><span class="glyphicon glyphicon-plus"></span> Add a comment</a></p>
 <% end %>
 
-<div class="add-comment">
+<div class="add-comment add-comment-form-container">
   <%= form_for PostComment.new, url: create_comment_path do |f| %>
     <%= f.hidden_field :post_id, value: @post.id %>
     <div class="field">
@@ -235,14 +238,14 @@
 </div>
 
 <% if user_signed_in? && current_user.has_role?(:developer) %>
-  <div class="panel panel-danger">
+  <div class="panel panel-danger post-developer-tools-container">
     <div class="panel-heading">
       <h3 class="panel-title">Developer tools</h3>
     </div>
     <div class="panel-body">
-      <ul>
-        <li><%= link_to "Update feedback cache", url_for(controller: :posts, action: :reindex_feedback, id: @post.id), method: :post %></li>
-        <li><%= link_to "Delete post", dev_delete_post_path(@post.id), method: :post, data: { confirm: "Are you sure you want to delete this post? This can't be undone." } %></li>
+      <ul class="post-developer-tools-list">
+        <li class="post-developer-tools-list-item"><%= link_to "Update feedback cache", url_for(controller: :posts, action: :reindex_feedback, id: @post.id), method: :post, class: 'post-developer-tools-update-feeback-cache-link' %></li>
+        <li class="post-developer-tools-list-item"><%= link_to "Delete post", dev_delete_post_path(@post.id), method: :post, data: { confirm: "Are you sure you want to delete this post? This can't be undone." }, class: 'post-developer-tools-delete-post-link' %></li>
       </ul>
     </div>
   </div>

--- a/app/views/reasons/show.html.erb
+++ b/app/views/reasons/show.html.erb
@@ -13,28 +13,28 @@
   <%= line_chart reason_accuracy_chart_path(@reason.id), colors: ["green", "red"], library: {"tooltip" => {'shared' => 'true'} } %>
 </div>
 
-<ul class="nav nav-tabs">
-  <li class="<%= 'active' if params[:filter].nil? or params[:filter] == 'all' %>">
+<ul class="nav nav-tabs post-table-nav-tabs post-table-nav-tabs-tp-fp-naa">
+  <li class="nav-tab nav-tab-all-results <%= 'active' if params[:filter].nil? or params[:filter] == 'all' %>">
     <%= link_to "All (#{@total})", reason_path(@reason, filter: nil) %>
   </li>
-  <li class="<%= 'active' if params[:filter] == 'tp' %>">
+  <li class="nav-tab nav-tab-tp <%= 'active' if params[:filter] == 'tp' %>">
     <%= link_to "True positives (#{@counts_by_feedback[:is_tp]})", reason_path(@reason, filter: 'tp') %>
   </li>
-  <li class="<%= 'active' if params[:filter] == 'fp' %>">
+  <li class="nav-tab nav-tab-fp <%= 'active' if params[:filter] == 'fp' %>">
     <%= link_to "False positives (#{@counts_by_feedback[:is_fp]})", reason_path(@reason, filter: 'fp') %>
   </li>
-  <li class="<%= 'active' if params[:filter] == 'naa' %>">
+  <li class="nav-tab nav-tab-naa <%= 'active' if params[:filter] == 'naa' %>">
     <%= link_to "NAA (#{@counts_by_feedback[:is_naa]})", reason_path(@reason, filter: 'naa') %>
   </li>
 </ul>
 
-<table class="table table-striped">
+<table class="table table-striped posts-table">
   <tbody>
     <%= render partial: 'posts/post', collection: @posts, cached: proc { |i| i.cachebreak } %>
   </tbody>
 </table>
 
-<div class="text-center">
+<div class="text-center pagination-container">
   <%= will_paginate @posts, renderer: BootstrapPagination::Rails %>
 </div>
 

--- a/app/views/rss/deleted.html.erb
+++ b/app/views/rss/deleted.html.erb
@@ -2,6 +2,6 @@
 
 <%= render 'posts/table', posts: @posts %>
 
-<div class="text-center">
+<div class="text-center pagination-container">
   <%= will_paginate @posts, renderer: BootstrapPagination::Rails %>
 </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -96,31 +96,31 @@
 <br />
 
 <% if @results.present? %>
-  <ul class="nav nav-tabs">
-    <li role="presentation" class="<%= "active" if params[:option].nil? and (params[:feedback_filter].nil? or params[:feedback_filter] == 'all') %>">
+  <ul class="nav nav-tabs post-table-nav-tabs search-results-nav-tabs post-table-nav-tabs-tp-fp-naa post-table-nav-tabs-has-graphs">
+    <li role="presentation" class="nav-tab nav-tab-all-results <%= "active" if params[:option].nil? and (params[:feedback_filter].nil? or params[:feedback_filter] == 'all') %>">
       <%= link_to "Results (#{@total_count})", search_path(request.query_parameters.merge!({option: nil, feedback_filter: nil})) %>
     </li>
-    <li class="<%= 'active' if params[:feedback_filter] == 'tp' %>">
+    <li class="nav-tab nav-tab-tp <%= 'active' if params[:feedback_filter] == 'tp' %>">
       <%= link_to "True positives (#{@counts_by_feedback[:is_tp]})", search_path(request.query_parameters.to_h.merge!({option: nil, feedback_filter: "tp"})) %>
     </li>
-    <li class="<%= 'active' if params[:feedback_filter] == 'fp' %>">
+    <li class="nav-tab nav-tab-fp <%= 'active' if params[:feedback_filter] == 'fp' %>">
       <%= link_to "False positives (#{@counts_by_feedback[:is_fp]})", search_path(request.query_parameters.to_h.merge!({option: nil, feedback_filter: "fp"})) %>
     </li>
-    <li class="<%= 'active' if params[:feedback_filter] == 'naa' %>">
+    <li class="nav-tab nav-tab-naa <%= 'active' if params[:feedback_filter] == 'naa' %>">
       <%= link_to "NAA (#{@counts_by_feedback[:is_naa]})", search_path(request.query_parameters.to_h.merge!({option: nil, feedback_filter: "naa"})) %>
     </li>
-    <li role="presentation" class="<%= "active" if params[:option] == "graphs" %>">
+    <li role="presentation" class="nav-tab nav-tab-graphs <%= "active" if params[:option] == "graphs" %>">
       <%= link_to "Graphs", search_path(request.query_parameters.to_h.merge({option: "graphs", anchor: "graphs"})) %>
     </li>
   </ul>
 
   <% if params[:option].nil? %>
-    <table class="table">
+    <table class="table search-results-table posts-table">
       <%= render @results, collection: :post %>
     </table>
-    <div class="text-center">
+    <div class="text-center pagination-container">
       <%= will_paginate @results, renderer: BootstrapPagination::Rails %>
-      <p class="text-muted">
+      <p class="text-muted link-to-json-format">
         <%= link_to "JSON (still subject to paging limits)", search_path(params: request.query_parameters, format: :json) %>
       </p>
     </div>
@@ -135,7 +135,7 @@
 <% end %>
 
 <% if user_signed_in? && current_user.has_role?(:developer) %>
-  <div class="panel panel-danger">
+  <div class="panel panel-danger developer-tools searc-developer-tools">
     <div class="panel-heading">
       <h4 class="panel-title">Developer</h4>
     </div>

--- a/app/views/spam_domains/_review_item.html.erb
+++ b/app/views/spam_domains/_review_item.html.erb
@@ -40,7 +40,7 @@
   <p><em>No whois data available.</em></p>
 <% end %>
 
-<table class="table">
+<table class="table posts-table">
   <tbody>
     <% @sites = Site.where(id: domain.posts.order(id: :desc).limit(100).map { |p| p.site_id }) %>
     <% domain.posts.limit(100).order(id: :desc).includes_for_post_row.each do |post| %>

--- a/app/views/spam_domains/show.html.erb
+++ b/app/views/spam_domains/show.html.erb
@@ -64,7 +64,7 @@
 <h3>Posts</h3>
 <p>This domain has been seen in <%= pluralize @counts[:all], 'post' %>, <%= @counts[:tp] %> TP.</p>
 
-<table class="table">
+<table class="table posts-table">
   <tbody>
     <% @posts.includes_for_post_row.each do |post| %>
       <%= render 'posts/post', post: post %>

--- a/app/views/spam_waves/_preview.html.erb
+++ b/app/views/spam_waves/_preview.html.erb
@@ -2,7 +2,7 @@
 <% if @posts.count == 0 %>
   <em>No posts caught.</em>
 <% else %>
-  <table class="table">
+  <table class="table posts-table">
     <% @posts.each do |p| %>
       <%= render 'posts/post', post: p, wrap_in_tr: true %>
     <% end %>

--- a/app/views/stack_exchange_users/show.html.erb
+++ b/app/views/stack_exchange_users/show.html.erb
@@ -8,7 +8,7 @@
 <br />
 <br />
 
-<table class="table">
+<table class="table posts-table">
   <tr>
     <th>Posts</th>
   </tr>


### PR DESCRIPTION
This PR:
* Adds `data-feedbackid` attributes to feedback elements
* Adds lots of semantic class names in post pages and post lists/tables. Post lists/tables are displayed in quite a few pages, so there are changes to a substantial number of files.

The intent is to make it easier/possible for JavaScript to make changes within post pages and post lists/tables. This PR shouldn't cause any functional or visible change to pages, but should allow working on/adapting/prototyping JavaScript changes.