### PR TITLE
Change per site spammers list to single control "Remove from list"

### DIFF
--- a/app/views/stack_exchange_users/_table.html.erb
+++ b/app/views/stack_exchange_users/_table.html.erb
@@ -1,6 +1,6 @@
 <% post_counts = false if post_counts.nil? %>
 
-<table class="table table-striped">
+<table class="table table-striped spammers-on-site-table">
   <thead>
     <tr>
       <th class="text-muted">MS ID</th>
@@ -10,32 +10,27 @@
       <% end %>
       <th>Reputation</th>
       <% if user_signed_in? && current_user.moderator_sites.exists? %>
-        <th colspan="2"></th>
-      <% elsif user_signed_in? %>
-        <th></th>
+        <th>Handled</th>
       <% end %>
     </tr>
   </thead>
   <tbody>
     <% users.each do |u| %>
-      <tr>
-        <td class="text-muted"><%= link_to u.id, url_for(controller: :stack_exchange_users, action: :show, id: u.id) %></td>
-        <td><%= link_to "#{u.user_id} (#{u.username})", "#{@site.site_url}/users/#{u.user_id}" %></td>
+      <tr class="spammer-row">
+        <td class="text-muted ms-id-cell"><%= link_to u.id, url_for(controller: :stack_exchange_users, action: :show, id: u.id) %></td>
+        <td class="se-id-cell"><%= link_to "#{u.user_id} (#{u.username})", "#{@site.site_url}/users/#{u.user_id}" %></td>
         <% if post_counts %>
           <td><%= u.posts.count %></td>
         <% end %>
-        <td><%= u.reputation %></td>
+        <td class="se-user-reputation-cell"><%= u.reputation %></td>
         <% if user_signed_in? && current_user.moderator_sites.exists? %>
-          <td><a href="#" class="not-spammer" data-uid="<%= u.id %>">Not a spammer</a></td>
-        <% end %>
-        <% if user_signed_in? && current_user.moderator_sites.exists? %>
-          <td><a href="#" class="not-spammer" data-uid="<%= u.id %>">Nuked</a></td>
+          <td class="moderator-action-cell"><a href="#" class="not-spammer" data-uid="<%= u.id %>">Remove from list</a></td>
         <% end %>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<div class="text-center">
+<div class="text-center pagination-container">
   <%= will_paginate users, renderer: BootstrapPagination::Rails %>
 </div>

--- a/app/views/stack_exchange_users/on_site.html.erb
+++ b/app/views/stack_exchange_users/on_site.html.erb
@@ -1,15 +1,19 @@
 <h3>Spammers on site: <%= @site.site_name %></h3>
-<p>An overview of users who have been caught spamming by Smokey on this site.
-  <% if user_signed_in? && current_user.moderator_sites.exists? %>
-    Click <em>Not a spammer</em> or <em>Nuked</em> to tell the system that user has been reviewed and the appropriate action taken;
-      the user will then be removed from this list.</p>
-  <% else %>
-    Users are removed from this list when a Stack Exchange  moderator indicates from this page that the user has been reviewed
-      and the appropriate action taken.
-  <% end %>
+<p>An overview of users who have been caught spamming by Smokey on this site. This list exists effectively as a "to do" list for moderators.
+The intent is that a site moderator will go through this list and appropriately handle each user. What "appropraitely handle" means is
+up to the moderator, but could be anywhere from nothing, through a moderator message, to a 365 day suspension and destroying the user. From
+metasmoke's point of view, this is just a list of non-deleted users who have had a post marked TP and who a moderator hasn't told metasmoke
+to remove the user from the list (i.e. mark the user as "handled").</p>
+<% if user_signed_in? && current_user.moderator_sites.exists? %>
+  <p>Click <em>Remove from list</em> to tell the system that the user has been reviewed and the appropriate action taken.
+    The user will then be removed from this list.</p>
+<% else %>
+  <p>Users are removed from this list when a Stack Exchange moderator indicates from this page that the user has been reviewed
+    and the appropriate action taken.</p>
+<% end %>
 
 
 <p class="text-muted">Data last updated: <%= @site.last_users_update.present? ? time_ago_in_words(@site.last_users_update) + ' ago' : "Never" %>
-  &mdash; <%= link_to "Update now", url_for(controller: :stack_exchange_users, action: :update_data, site: @site.id), method: :post %></p>
+  &mdash; <%= link_to "Update now to automatically remove deleted users", url_for(controller: :stack_exchange_users, action: :update_data, site: @site.id), method: :post %></p>
 
 <%= render 'table', users: @users %>


### PR DESCRIPTION
Having two controls "Not a spammer" and "Nuked" which do exactly the same thing has been confusing. This changes it so there's a single control, "Remove from list", for each user. Some additional explanation as to what the list is for is also provided.