### PR TITLE
Topbar SD status: only update when there are changes.

### DIFF
--- a/app/javascript/cable/topbar.js
+++ b/app/javascript/cable/topbar.js
@@ -23,30 +23,60 @@ $(() => {
       }
       if (lastPing != null) {
         $('.navbar .status').data('last-ping', lastPing);
+        // Update the display for the new last ping time.
+        updateStatus();
       }
     }
   });
 
-  setInterval(() => {
+  function setOnlyStatusClassIfNotHasClass(el, statusClass) {
+    if (!el.hasClass(statusClass)) {
+      el.removeClass('status-good status-warning status-critical')
+        .addClass(statusClass);
+    }
+  }
+
+  let updateStatusTimer = 0;
+  function updateStatus() {
+    clearTimeout(updateStatusTimer);
+    if (document.hidden) {
+      // If the document is hidden, then there isn't much benefit from updating the UI. The
+      //   UI will be updated when the visibility of the page changes.
+      return;
+    }
     const $status = $('.navbar #smokedetector-status');
     const lastPing = parseFloat($status.data('last-ping')) * 1e3;
     const ago = Date.now() - lastPing;
     const title = `Last ping was ${moment(lastPing).fromNow()}.`;
     let status = 'critical';
+    // The .fromNow() method only provides minute resolution. So time passing can cause the status text
+    //   to change change at the earliest at the point when "ago" passes the next minute.
+    let msToNextPossibleChange = 60e3 - (ago % 60e3); // Time to next minute ago;
     if (ago < 90e3) {
       status = 'good';
+      msToNextPossibleChange = Math.min(msToNextPossibleChange, 90e3 - ago); // Time to 1.5 minutes ago, if less;
     }
     else if (ago < 3 * 60e3) {
       status = 'warning';
+      msToNextPossibleChange = Math.min(msToNextPossibleChange, 3 * 60e3 - ago); // Time to 3 minutes ago, if less;
     }
-    $('.navbar-toggle').removeClass('status-good status-warning status-critical')
-                       .addClass(`status-${status}`);
-    $status.removeClass('status-good status-warning status-critical')
-           .addClass(`status-${status}`)
-           .attr('data-original-title', title)
-           .tooltip()
-           .parent()
+    const navbarToggle = $('.navbar-toggle');
+    const statusClass = `status-${status}`;
+    setOnlyStatusClassIfNotHasClass(navbarToggle, statusClass);
+    setOnlyStatusClassIfNotHasClass($status, statusClass);
+    const currentOrigTitle = $status.attr('data-original-title');
+    const currentTooltipInnerText = $status.find('.status + .tooltip .tooltip-inner')
+                                           .text();
+    if (currentOrigTitle !== title || currentTooltipInnerText !== title) {
+      $status.attr('data-original-title', title)
+             .tooltip()
+             .parent()
              .find('.status + .tooltip .tooltip-inner')
              .text(title);
-  }, 1000);
+    }
+    // Get called again just after when anything displayed to the user might update.
+    updateStatusTimer = setTimeout(updateStatus, msToNextPossibleChange + 1);
+  }
+  updateStatus();
+  window.addEventListener('visibilitychange', updateStatus);
 });


### PR DESCRIPTION
Reduce the frequency at which UI updates are performed to just those where the status might have changed. The DOM will now only be changed when there are differences the user could see.

Currently, there's an interval timer which runs every second to update the MS topbar status text, regardless of if an update is needed. While this seems like a small amount of processing, it becomes significant when one has a large number of tabs open to MS. Given that I often have a few to several hundred tabs open to MS pages, the DOM changes end up happening hundreds of times a second.

I also find it annoying/distracting for the browser's DOM inspector to continuously indicate that there are DOM changes when the changes are just clearing and then re-applying the same thing.

This PR changes the logic such that the DOM changes:
1. Visible updates aren't made when the page isn't visible, but are updated immediately when the page becomes visible and continue to be updated while the page is visible.
2. The DOM is only updated when there's actually a change, rather than always clearing it and then re-applying the same things.
3. The check to see if there are changes to update is only called when it's possible for there to have been changes which are visible (i.e. when the last ping status text might have changed, when the status color might have changed, or when new data is received from MS).

Overall, while the page is visible, but not being interacted with by the user, this should reduce the amount of processing needed and the actual changes to the DOM by more than an order of magnitude. For all non-visible tabs it should eliminate the processing which isn't directly the result of obtaining new information from MS.