### PR TITLE
Return search & flagging to topbar while still being responsive and not expanding the topbar vertically.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -448,3 +448,140 @@ body .profiler-results {
 .wait-for-AJAX.wait-for-AJAX {
   cursor: progress;
 }
+
+/* Search and flagging back in topbar, but responsive */
+.navbar-static-top {
+  .navbar-nav > li > a.glyphicon {
+      display: none;
+  }
+  @media (min-width: 768px) {
+    @media (max-width: 1000px) {
+      .navbar-nav {
+        > li > a.glyphicon {
+          display: inline-block;
+          min-width: 40px;
+          text-align: center;
+        }
+        > li:is(.nav-tab-flagging, .nav-tab-search) > a:not(.glyphicon) {
+          display: none;
+        }
+        > li.nav-tab-review > a {
+          position: relative;
+          > .reviews-count {
+              position: absolute;
+              bottom: 0;
+              left: 2.3em;
+              transform: scale(.9) translateX(-50%);
+          }
+        }
+      }
+      .home.inline {
+        margin-left: 0;
+        span {
+          padding-left: .5vw;
+        }
+        + .navbar-brand {
+          padding-left: 1vw;
+          padding-right: 0.5vw;
+        }
+      }
+      .container-fluid {
+        padding-left: .5vw;
+        padding-right: .5vw;
+      }
+      .navbar-right.navbar-right {
+        margin-right: 0px;
+      }
+    }
+    @media (max-width: 1100px) {
+      .commit-sha.commit-sha {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: min-content !important;
+        width: min-content;
+        > a {
+          padding: 0 2px 0 0 !important;
+          line-height: 10px;
+          > code {
+            padding: 0;
+          }
+        }
+      }
+      .container-fluid .navbar-collapse .navbar-nav:not(.navbar-right) {
+        justify-content: space-around;
+      }
+    }
+    .navbar-right > .nav-tab-ms-username > a {
+      white-space: break-spaces;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      padding-bottom: 0px;
+      height: 50px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 16px;
+      padding-top: 17px;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      margin-right: .5vw;
+    }
+    .container-fluid .navbar-collapse .nav > li > a {
+      padding-left: MIN(.9vw, 15px);
+      padding-right: MIN(.9vw, 15px);
+    }
+    .container-fluid {
+      display: flex;
+      .navbar-collapse {
+        display: flex !important;
+        justify-content: space-between;
+        flex-grow: 1;
+        > .navbar-nav {
+          flex-grow: 10;
+          display: flex;
+          > li {
+            white-space: nowrap;
+            height: 50px;
+          }
+        }
+        .navbar-right {
+          justify-content: flex-end;
+          display: flex;
+          > .nav-tab-ms-username > a {
+            .caret {
+              display: none;
+            }
+            /*Simulate .caret*/
+            &:after {
+              content: " ";
+              position: absolute;
+              top: 24px;
+              right: 0px;
+              display: inline-block;
+              width: 0;
+              height: 0;
+              margin-left: 2px;
+              border-top: 4px solid;
+              border-right: 4px solid transparent;
+              border-left: 4px solid transparent;
+            }
+          }
+        }
+      }
+    }
+    .home.inline span {
+      padding-left: .5vw;
+    }
+  }
+  @media (min-width: 1001px) and (max-width: 1100px) {
+    .navbar-right > .nav-tab-ms-username > a {
+      margin-right: 15px;
+    }
+  }
+  @media (min-width: 1101px) {
+    .container-fluid .navbar-collapse .navbar-nav:not(.navbar-right) {
+      justify-content: flex-start;
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,19 +49,28 @@
       <% Rack::MiniProfiler.step('Rendering: layouts/application/nav') do %>
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-        <ul class="nav navbar-nav">
-          <%= nav_link PostsController %>
+        <ul class="nav navbar-nav navbar-left">
+          <%= nav_link PostsController, class: 'nav-tab-posts' %>
           <% if !user_signed_in? %>
-            <%= nav_link GraphsController, label: 'graphs' %>
+            <%= nav_link GraphsController, label: 'graphs', class: 'nav-tab-graphs' %>
           <% end %>
-          <li class='<%= (controller.class == DashboardController && controller.action_name == :index) ? "active" : "" %>'><%= link_to "reasons", reasons_path %></li>
+          <% flagging_status = FlagSetting['flagging_enabled'] == '0' ? 'critical' : (FlagSetting['dry_run'] == '1' ? 'warning' : 'good') %>
+          <li class="nav-tab-search <%= (controller.class == SearchController && controller.action_name.to_sym == :index) ? "active" : "" %>">
+            <%= link_to 'search', search_path, class: 'nav-search-link' %>
+            <%= link_to 'search', search_path, class: 'nav-search-link glyphicon glyphicon-search', title: 'search' %>
+          </li>
+          <li class="nav-tab-flagging status status-<%= flagging_status %> <%= (controller.class == FlagSettingsController && controller.action_name.to_sym == :dashboard) ? "active" : "" %>">
+            <%= link_to 'flagging', flagging_path, class: 'nav-flagging-link' %>
+            <%= link_to 'flagging', flagging_path, class: 'nav-flagging-link glyphicon glyphicon-flag', title: 'flagging' %>
+          </li>
+          <li class='nav-tab-reasons <%= (controller.class == DashboardController && controller.action_name == :index) ? "active" : "" %>'><%= link_to "reasons", reasons_path %></li>
           <% Rack::MiniProfiler.step('Rendering: layouts/application/nav/review') do %>
           <% if user_signed_in? && current_user.has_role?("reviewer") %>
             <% q_counts = redis.smembers("review_queues").map { |i| [i.to_i, redis.scard("review_queue/#{i}/unreviewed")] }.to_h %>
             <% total_count = q_counts.sum { |_k, v| v } %>
             <% label = raw("review <span class='reviews-count badge'>#{total_count != 0 && current_user&.has_role?(:reviewer) ? total_count : nil}</span>") %>
             <% Rack::MiniProfiler.step('Rendering: layouts/application/nav/review/dropdown') do %>
-            <%= nav_dropdown ReviewQueuesController, label: label do %>
+            <%= nav_dropdown ReviewQueuesController, label: label, class: 'nav-tab-review' do %>
               <% ReviewQueue.where(privileges: current_user.roles.map(&:name)).each do |rq| %>
                 <li>
                   <%= link_to review_queue_path(rq.name) do %>
@@ -73,7 +82,7 @@
             <% end %>
           <% end %>
           <% end %>
-          <%= nav_dropdown AdminController, label: 'tools' do %>
+          <%= nav_dropdown AdminController, label: 'tools', class: 'nav-tab-tools' do %>
             <%= nav_link SpamDomainsController, label: 'Domains' %>
             <%= nav_link DomainTagsController, label: 'Domain Tags' %>
             <%= nav_link DomainGroupsController, label: 'Domain Groups' %>
@@ -84,7 +93,7 @@
           <% end %>
 
           <% if current_user&.has_role?(:core) %>
-            <%= nav_dropdown DashboardController, action: 'new_dash', label: 'core' do %>
+            <%= nav_dropdown DashboardController, action: 'new_dash', label: 'core', class: 'nav-tab-core' do %>
               <% unless current_user&.has_role?(:admin) %>
                 <%= nav_link AdminController, label: 'User Data & Roles', action: :users %>
                 <li role="separator" class="divider"></li>
@@ -113,7 +122,7 @@
           <% end %>
 
           <% if current_user&.has_role?(:admin) %>
-            <%= nav_dropdown AdminController, label: 'admin' do %>
+            <%= nav_dropdown AdminController, label: 'admin', class: 'nav-tab-admin' do %>
               <%= nav_link AdminController, label: 'User Data & Roles', action: :users %>
               <%= nav_link APIKeysController, label: 'API Keys' %>
               <%= nav_link SiteSettingsController, label: 'Website Configuration' %>
@@ -122,7 +131,7 @@
           <% end %>
 
           <% if current_user&.has_role?(:developer) %>
-            <%= nav_dropdown DashboardController, action: 'new_dash', label: 'dev' do %>
+            <%= nav_dropdown DashboardController, action: 'new_dash', label: 'dev', class: 'nav-tab-dev' do %>
               <%= nav_link DumpsController, label: 'Database Dumps', action: :index %>
               <%= nav_link DeveloperController, label: 'Production log', action: :production_log %>
               <%= nav_link RedisLogController, label: 'Request log', action: :index %>
@@ -131,7 +140,7 @@
 
           <%= nav_link StatusController, attrs: {
             id: 'smokedetector-status',
-            class: ['status', "status-#{SmokeDetector.status_color}"],
+            class: ["nav-tab-SD-status", 'status', "status-#{SmokeDetector.status_color}"],
             data: {
               last_ping: SmokeDetector.select(:last_ping).order(last_ping: :desc).first&.last_ping&.to_f,
               toggle: 'tooltip',
@@ -141,7 +150,7 @@
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <% if user_signed_in? %>
-            <%= nav_dropdown label: current_user.username || current_user.email do %>
+            <%= nav_dropdown label: current_user.username || current_user.email, class: 'nav-tab-ms-username' do %>
               <%= nav_link CustomSessionsController, label: 'Sign Out', action: :destroy, link_attrs: { method: 'delete' } %>
               <%= nav_link CustomRegistrationsController, label: 'Account Settings', action: :edit %>
               <%= nav_link UsersController, action: :apps, label: 'Apps' %>
@@ -154,13 +163,13 @@
               <% end %>
             <% end %>
           <% else %>
-            <%= nav_link CustomSessionsController, label: 'sign in', action: :new %>
-            <%= nav_link CustomRegistrationsController, label: 'sign up', action: :new %>
+            <%= nav_link CustomSessionsController, label: 'sign in', action: :new, class: 'nav-tab-sign-in' %>
+            <%= nav_link CustomRegistrationsController, label: 'sign up', action: :new , class: 'nav-tab-sign-up' %>
           <% end %>
           <% if CurrentCommit.present? %>
             <%= nav_link CodeStatusController, label: '', attrs: {
               title: "Controller: #{controller.class}##{controller.action_name}",
-              class: 'commit-sha',
+              class: 'nav-tab-current-commit commit-sha',
               data: {
                 sha: CurrentCommit
               }
@@ -172,15 +181,6 @@
       </div><!-- /.navbar-collapse -->
     <% end %>
     </div><!-- /.container-fluid -->
-    <ul class="icon-nav-bar">
-      <% flagging_status = FlagSetting['flagging_enabled'] == '0' ? 'critical' : (FlagSetting['dry_run'] == '1' ? 'warning' : 'good') %>
-      <li class="status status-<%= flagging_status %> <%= (controller.class == FlagSettingsController && controller.action_name.to_sym == :dashboard) ? "active" : "" %>">
-        <%= link_to '', flagging_path, class: 'glyphicon glyphicon-flag' %>
-      </li>
-      <li class="<%= (controller.class == SearchController && controller.action_name.to_sym == :index) ? "active" : "" %>">
-        <%= link_to '', search_path, class: 'glyphicon glyphicon-search' %>
-      </li>
-    </ul>
   </nav>
   <div class="initial-content col-md-offset-1 col-md-10">
     <% Rack::MiniProfiler.step('Rendering: layouts/application/announcements') do %>


### PR DESCRIPTION
The search and flagging navigation buttons in the icon bar at the top-left obscure page content at some viewport widths. In addition, at least to me, having them in the left icon bar has always felt a bit clunky and doesn't feel like it really "fits" with the rest of the site design.

This PR returns the search and flagging selections to the topbar from the icon bar on the top-left. The stated reason for moving them to an icon bar was so the topbar didn't wrap (and take up substantial additional vertical space). This makes the topbar  responsive through the widths which are not put into a hamburger menu (i.e, viewports >=768px wide), such that the buttons in the topbar don't wrap. However, if the user's MS username is too long it will wrap into a second line, which is kept within the existing height of the topbar. If the user's MS username is too long to fit into two lines, then it's truncated with an ellipse.