### PR TITLE
Show "Chat" as a feedback source

### DIFF
--- a/app/views/feedbacks/_feedback.html.erb
+++ b/app/views/feedbacks/_feedback.html.erb
@@ -1,3 +1,3 @@
 <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top"
-      title="<%= feedback.user.present? ? "#{feedback.user.try(:username)} (From Review)" : feedback.user_name %>: <%= feedback.feedback_type %>"
+      title="<%= feedback.user.present? ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || ("Chat" if feedback.chat_user_id.present?) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>"
       class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>

--- a/app/views/feedbacks/clear.html.erb
+++ b/app/views/feedbacks/clear.html.erb
@@ -28,7 +28,7 @@
     <% @feedbacks.each do |feedback| %>
       <tr class="<%= feedback.is_invalidated? ? "danger" : "" %>">
         <td class="<%= element_class_for_feedback feedback %>"><%= feedback.feedback_type %></td>
-        <td><%= feedback.user_name || ("#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" if feedback.user.present?) %></td>
+        <td><%= feedback.user_name || ("#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || ("Chat" if feedback.chat_user_id.present?) || "Review"})" if feedback.user.present?) %></td>
         <td><span title="<%= feedback.created_at %>"><%= feedback.created_at.present? ? time_ago_in_words(feedback.created_at) + " ago" : "no data" %></span></td>
         <td><%= link_to("delete", delete_feedback_path(feedback), method: :delete) if (!feedback.is_invalidated? && (current_user.has_role?(:admin) || feedback.user_id == current_user.id)) %></td>
       </tr>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -24,7 +24,7 @@
     <% unless post.feedbacks.empty? or hide_feedbacks %>
       <strong class="feedbacks-container">
          <% post.feedbacks.each do |feedback| %>
-           <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? or feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+           <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? or feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || ("Chat" if feedback.chat_user_id.present?) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>
          <% end %>
       </strong>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,7 @@
   <% unless @is_review_item %>
     <strong class="post-feedbacks feedbacks-container">
        <% @post.feedbacks.each do |feedback| %>
-         <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>
+         <span style="<%= "font-weight:normal" if feedback.is_naa? %>" data-feedbackid="<%= feedback.id %>" data-toggle="tooltip" data-placement="top" title="<%= (feedback.user.present? || feedback.api_key_id.present?) ? "#{feedback.user.try(:username)} (From #{feedback.api_key.try(:app_name) || ("Chat" if feedback.chat_user_id.present?) || "Review"})" : feedback.user_name %>: <%= feedback.feedback_type %>" class="<%= element_class_for_feedback feedback %> feedback-span"><%= element_symbol_for_feedback(feedback).html_safe %></span>
        <% end %>
     </strong>
   <% end %>


### PR DESCRIPTION
Currently, if a feedback was given via chat, it's indicated as "From Review". This changes that to "From Chat" for those feedbacks which were provided via chat (i.e. where there's a valid `chat_user_id`.