### PR TITLE
By default, prevent download and display of image in post previews, unless requested by the user

### DIFF
--- a/app/assets/stylesheets/post_preview.scss
+++ b/app/assets/stylesheets/post_preview.scss
@@ -2,14 +2,6 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.posts-table {
-  table-layout: fixed;
-}
-.post-body-pre-block {
-	max-height: MIN(90vh, 800px);
-	display: block;
-}
-
 
 /* The CSS/SCSS code below is largely copied from FIRE, with a significant portion of that
  * being copied from Stack Exchange/Stacks.  FIRE
@@ -20,16 +12,21 @@
  */
 
 .post-body-panel-preview > .panel > .panel-body {
-	max-height: MIN(90vh, 800px);
-	display: block;
-	overflow: auto;
-
+  img {
+    max-width: 100%;
+  }
   img[src^='https://via.placeholder.com'] {
     cursor: pointer;
     box-shadow: 0 0 10px -2px #646464;
   }
-  a img[src^='https://via.placeholder.com'] {
-    box-shadow: unset;
+  a {
+    font-weight: bold;
+    text-decoration: underline;
+    padding: 1px 5px;
+    border-radius: 3px;
+    box-shadow: 0 0 10px -2px #646464;
+    display: inline-block;
+    word-wrap: anywhere;
   }
   a.onebox-link[data-onebox-id] {
     position: relative;
@@ -41,17 +38,8 @@
     top: -1.25em;
     font-size: 80%;
   }
-  img {
-    max-width: 100%;
-  }
-  a {
-    font-weight: bold;
-    text-decoration: underline;
-    padding: 1px 5px;
-    border-radius: 3px;
-    box-shadow: 0 0 10px -2px #646464;
-    display: inline-block;
-    word-wrap: anywhere;
+  a img[src^='https://via.placeholder.com'] {
+    box-shadow: unset;
   }
   li {
     margin-left: 10px;
@@ -165,21 +153,21 @@
   pre {
     margin-bottom: 1em;
     width: auto;
+    max-height: 100px;
     overflow: auto;
     font-family: Fira Code, Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
     font-size: 13px;
     background-color: #eff0f1;
-    /*box-shadow: 0 0 10px -1px #646464;*/
-    /*border-radius: 3px;*/
+    box-shadow: 0 0 10px -1px #646464;
+    border-radius: 3px;
     padding: 6px 10px;
+    -webkit-transition: max-height 0.4s;
+    -moz-transition: max-height 0.4s;
+    transition: max-height 0.4s;
     overflow-wrap: normal;
-    background-color: #f7f7f7;
   }
   pre code {
     padding: 0;
-    background-color: transparent;
-    max-height: MIN(75vh, 600px);
-    display: block;
   }
   .snippet-code {
     border: 1px solid #e4e6e8;
@@ -190,13 +178,12 @@
     font-size: 13px;
     background-color: #eff0f1;
     padding: 1px 5px;
-    color: #111;
   }
   a.post-tag {
     display: inline-block;
     padding: .4em .5em;
     margin: 2px 2px 2px 0;
-    font-size: 12px;
+        font-size: 11px;
     line-height: 1;
     white-space: nowrap;
     text-decoration: none;
@@ -245,11 +232,8 @@
     padding: .8em .8em .8em 1em;
     color: #535a60;
     background-color: #fbf2d4;
-    background-color: #fbf2d4a8;
     color: #0d0e0f;
     border-left: 2px solid #ffeb8e;
-    font-size: unset;
-    border-left: unset;
   }
   blockquote::before {
     content: "";
@@ -298,11 +282,8 @@
   .spoiler.is-visible::after {
     opacity: 0;
   }
-  .fire-deleted .s-table th {
-    background-color: var(--red-075);
-  }
   .s-table-container {
-    margin-bottom: 1.1em;
+        margin-bottom: var(--s-prose-spacing);
     overflow-x: auto;
     scrollbar-color: var(--scrollbar) transparent;
   }
@@ -395,3 +376,72 @@ body,
   --scrollbar: hsla(0, 0%, 0%, 0.2);
 }
 
+/* END code copied from FIRE */
+
+/* The following applies CSS for MS and overrides some that's in the FIRE CSS.
+   It's done this way to make comparison with the CSS in FIRE easier.
+ */
+
+.posts-table {
+  table-layout: fixed;
+}
+.post-body-pre-block {
+  display: block;
+}
+
+.post-body-panel-preview > .panel > .panel-body {
+  display: block;
+  overflow: auto;
+
+  pre {
+    max-height: unset;
+    box-shadow: unset;
+    border-radius: unset;
+    -webkit-transition: unset;
+    -moz-transition: unset;
+    transition: unset;
+    background-color: #f7f7f7;
+  }
+  pre code {
+    background-color: transparent;
+    display: block;
+  }
+  code {
+    color: #111;
+  }
+  a {
+    font-weight: unset;
+    box-shadow: unset;
+    display: unset;
+  }
+  a.post-tag {
+    font-size: 12px;
+  }
+  blockquote {
+    background-color: #fbf2d4a8;
+    font-size: unset;
+    border-left: unset;
+  }
+  .s-table-container {
+    margin-bottom: 1.1em;
+  }
+  /* Use the same font sizes for headings as Stack Exchange does. */
+  h1 {
+    font-size: 27px;
+  }
+  h2 {
+    font-size: 21px;
+  }
+  h3 {
+    font-size: 19px;
+  }
+  h4 {
+    font-size: 17px;
+  }
+  h5 {
+    font-size: 15px;
+  }
+  h6 {
+    font-size: 13px;
+  }
+}

--- a/app/assets/stylesheets/post_preview.scss
+++ b/app/assets/stylesheets/post_preview.scss
@@ -31,6 +31,16 @@
   a img[src^='https://via.placeholder.com'] {
     box-shadow: unset;
   }
+  a.onebox-link[data-onebox-id] {
+    position: relative;
+  }
+  a.onebox-link[data-onebox-id][href*="github.com/"]:after {
+    content: "GitHub onebox link";
+    position: absolute;
+    right: 0;
+    top: -1.25em;
+    font-size: 80%;
+  }
   img {
     max-width: 100%;
   }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -40,3 +40,7 @@ body.posts .bootstrap-select .btn.dropdown-toggle {
   margin-left: 2em;
   margin-right: 2em;
 }
+
+.posts-table {
+  table-layout: fixed;
+}

--- a/app/assets/stylesheets/posts_preview.scss
+++ b/app/assets/stylesheets/posts_preview.scss
@@ -1,0 +1,387 @@
+// Place all the styles related to the posts preview here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+.posts-table {
+  table-layout: fixed;
+}
+.post-body-pre-block {
+	max-height: MIN(90vh, 800px);
+	display: block;
+}
+
+
+/* The CSS/SCSS code below is largely copied from FIRE, with a significant portion of that
+ * being copied from Stack Exchange/Stacks.  FIRE
+ * (https://github.com/Charcoal-SE/userscripts/blob/master/fire/fire.user.js) is under a
+ * dual Apache License 2.0 and MIT license.  The intent is for the code below and the code
+ * in FIRE to remain relatively in sync, but there are differences. Thus, this should
+ * primarily remain as mostly CSS, so comparisons with FIRE are easier.
+ */
+
+.post-body-panel-preview > .panel > .panel-body {
+	max-height: MIN(90vh, 800px);
+	display: block;
+	overflow: auto;
+
+  img[src^='https://via.placeholder.com'] {
+    cursor: pointer;
+    box-shadow: 0 0 10px -2px #646464;
+  }
+  a img[src^='https://via.placeholder.com'] {
+    box-shadow: unset;
+  }
+  img {
+    max-width: 100%;
+  }
+  a {
+    font-weight: bold;
+    text-decoration: underline;
+    padding: 1px 5px;
+    border-radius: 3px;
+    box-shadow: 0 0 10px -2px #646464;
+    display: inline-block;
+    word-wrap: anywhere;
+  }
+  li {
+    margin-left: 10px;
+  }
+  h1 {
+    font-size: 23px;
+  }
+  h2 {
+    font-size: 21px;
+  }
+  h3 {
+    font-size: 19px;
+  }
+  h4 {
+    font-size: 17px;
+  }
+  h5 {
+    font-size: 15px;
+  }
+  h6 {
+    font-size: 13px;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    line-height: 1.3;
+    margin: 0 0 .5em 0;
+    font-weight: bold;
+  }
+  img + h1,
+  img + h2,
+  img + h3,
+  img + h4,
+  img + h5,
+  img + h6,
+  dl + h1,
+  dl + h2,
+  dl + h3,
+  dl + h4,
+  dl + h5,
+  dl + h6,
+  p + h1,
+  p + h2,
+  p + h3,
+  p + h4,
+  p + h5,
+  p + h6,
+  pre + h1,
+  pre + h2,
+  pre + h3,
+  pre + h4,
+  pre + h5,
+  pre + h6,
+  blockquote + h1,
+  blockquote + h2,
+  blockquote + h3,
+  blockquote + h4,
+  blockquote + h5,
+  blockquote + h6,
+  table + h1,
+  table + h2,
+  table + h3,
+  table + h4,
+  table + h5,
+  table + h6,
+  .s-table-container + h1,
+  .s-table-container + h2,
+  .s-table-container + h3,
+  .s-table-container + h4,
+  .s-table-container + h5,
+  .s-table-container + h6,
+  .s-link-preview + h1,
+  .s-link-preview + h2,
+  .s-link-preview + h3,
+  .s-link-preview + h4,
+  .s-link-preview + h5,
+  .s-link-preview + h6,
+  dd + h1,
+  dd + h2,
+  dd + h3,
+  dd + h4,
+  dd + h5,
+  dd + h6,
+  ul + h1,
+  ul + h2,
+  ul + h3,
+  ul + h4,
+  ul + h5,
+  ul + h6,
+  ol + h1,
+  ol + h2,
+  ol + h3,
+  ol + h4,
+  ol + h5,
+  ol + h6 {
+    margin-top: 1em;
+  }
+  a .href {
+    display: none;
+    word-break: break-all;
+  }
+  a:hover .href {
+    display: inline;
+  }
+  a:hover .text {
+    display: none;
+  }
+  pre {
+    margin-bottom: 1em;
+    width: auto;
+    overflow: auto;
+    font-family: Fira Code, Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
+    font-size: 13px;
+    background-color: #eff0f1;
+    /*box-shadow: 0 0 10px -1px #646464;*/
+    /*border-radius: 3px;*/
+    padding: 6px 10px;
+    overflow-wrap: normal;
+    background-color: #f7f7f7;
+  }
+  pre code {
+    padding: 0;
+    background-color: transparent;
+    max-height: MIN(75vh, 600px);
+    display: block;
+  }
+  .snippet-code {
+    border: 1px solid #e4e6e8;
+    padding: 10px;
+  }
+  code {
+    font-family: Fira Code,Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,sans-serif;
+    font-size: 13px;
+    background-color: #eff0f1;
+    padding: 1px 5px;
+    color: #111;
+  }
+  a.post-tag {
+    display: inline-block;
+    padding: .4em .5em;
+    margin: 2px 2px 2px 0;
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    text-decoration: none;
+    text-align: center;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 3px;
+    box-shadow: unset;
+    font-weight: unset;
+  }
+  a.post-tag {
+    color: rgb(44, 88, 119);
+    background-color: rgb(225, 236, 244);
+    border-color: rgb(225, 236, 244);
+  }
+  a.post-tag:hover {
+    color: rgb(57, 115, 157);
+    background-color: rgb(208, 227, 241);
+    border-color: rgb(208, 227, 241);
+  }
+  a.post-tag.required-tag {
+    color: rgb(59, 64, 69);
+    background-color: rgb(227, 230, 232);
+    border-color: rgb(186, 191, 196);
+  }
+  a.post-tag.required-tag:hover {
+    color: rgb(35, 38, 41);
+    background-color: rgb(214, 217, 220);
+    border-color: rgb(159, 166, 173);
+  }
+  a.post-tag.moderator-tag {
+    color: rgb(194, 46, 50);
+    background-color: rgb(253, 242, 242);
+    border-color: rgb(249, 210, 211);
+
+  }
+  a.post-tag.moderator-tag:hover {
+    color: rgb(171, 38, 42);
+    background-color: rgb(249, 210, 211);
+    border-color: rgb(244, 180, 182);
+  }
+  blockquote {
+    quotes: none;
+    position: relative;
+    margin: 0 1em 1.1em 1em;
+    padding: .8em .8em .8em 1em;
+    color: #535a60;
+    background-color: #fbf2d4;
+    background-color: #fbf2d4a8;
+    color: #0d0e0f;
+    border-left: 2px solid #ffeb8e;
+    font-size: unset;
+    border-left: unset;
+  }
+  blockquote::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    border-radius: 8px;
+    background: #c8ccd0;
+  }
+  .spoiler {
+    background: #eff0f1;
+    border-radius: 5px;
+    color: #242729;
+    cursor: pointer;
+    min-height: 48px;
+  }
+  .spoiler::after {
+    content: attr(data-spoiler) " ";
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='rgb(132, 141, 149)' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M9 17A8 8 0 119 1a8 8 0 010 16zM8 4v6h2V4H8zm0 8v2h2v-2H8z'%3E%3C/path%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center right;
+    font-size: 13px;
+    color: #6a737c;
+    padding-right: 22px;
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    transition: opacity .1s ease-in-out;
+    pointer-events: none;
+  }
+  .spoiler > * {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .1s ease-in-out;
+  }
+  .spoiler.is-visible {
+    cursor: auto;
+  }
+  .spoiler.is-visible > * {
+    visibility: visible;
+    opacity: 1;
+  }
+  .spoiler.is-visible::after {
+    opacity: 0;
+  }
+  .fire-deleted .s-table th {
+    background-color: var(--red-075);
+  }
+  .s-table-container {
+    margin-bottom: 1.1em;
+    overflow-x: auto;
+    scrollbar-color: var(--scrollbar) transparent;
+  }
+  .s-table-container:last-child,
+  .s-table-container:only-child {
+    margin-bottom: 0;
+  }
+  .s-table-container::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+    background-color: transparent;
+  }
+  .s-table-container::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: transparent;
+  }
+  .s-table-container::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: var(--scrollbar);
+  }
+  .s-table-container::-webkit-scrollbar-corner {
+    background-color: transparent;
+    border-color: transparent;
+  }
+  .s-table {
+    display: table;
+    width: 100%;
+    max-width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    font-size: 13px;
+  }
+  .s-table th,
+  .s-table td {
+    padding: 8px;
+    border-top: 1px solid var(--black-100);
+    border-left: 1px solid var(--black-100);
+    border-right: 1px solid var(--black-100);
+    vertical-align: middle;
+    color: var(--fc-medium);
+    text-align: left;
+  }
+  .s-table th {
+    font-weight: bold;
+    color: var(--fc-dark);
+  }
+  .s-table thead th {
+    vertical-align: bottom;
+    white-space: nowrap;
+    background-color: var(--black-025);
+    line-height: 1.15384615;
+  }
+  .s-table tbody th {
+    font-weight: normal;
+  }
+  .s-table tr:last-of-type td,
+  .s-table tr:last-of-type th {
+    border-bottom: 1px solid var(--black-100);
+  }
+  .s-table tbody + tbody {
+    border-top: 2px solid var(--black-100);
+  }
+  kbd {
+    border: 1px solid rgb(159, 166, 173);
+    border-top-color: rgb(159, 166, 173);
+    box-shadow: rgba(12, 13, 14, 0.15) 0px 1px 1px 0px, rgb(255, 255, 255) 0px 1px 0px 0px inset;
+    background-color: rgb(227, 230, 232);
+    border-radius: 3px;
+    color: rgb(35, 38, 41);
+    display: inline-block;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Adjusted", "Segoe UI", "Liberation Sans", sans-serif;
+    font-size: 12px;
+    line-height: 1.5;
+    margin: 0 .1em;
+    overflow-wrap: break-word;
+    padding: .1em .6em;
+    text-shadow: rgb(255, 255, 255) 0px 1px 0px;
+  }
+} /* .post-body-panel-preview > .panel > .panel-body */
+
+/* Used in table CSS; Largely copied from SE's Stacks CSS*/
+body,
+.theme-light__forced {
+  --black-025: #fafafb;
+  --black-100: #d6d9dc;
+  --red-075: #f9d3d780;
+  --fc-dark: hsl(210, 8%, 5%);
+  --fc-medium: hsl(210, 8%, 25%);
+  --fc-light: hsl(210, 8%, 45%);
+  --scrollbar: hsla(0, 0%, 0%, 0.2);
+}
+

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -39,6 +39,7 @@ import '../site_settings';
 import '../comments';
 import '../spam_waves';
 import '../general_fixes';
+import '../post_preview';
 
 import { onLoad, installSelectpickers, uuid4, hashCode } from '../util';
 

--- a/app/javascript/post_preview.js
+++ b/app/javascript/post_preview.js
@@ -1,0 +1,484 @@
+import { onLoad, route, addLocalSettingsPanel } from './util';
+
+(() => {
+  /* Generate post previews
+   * Post previews are generated in JavaScript in order to not download images over the
+   * network by default.  It also allows a more accurate generation of post contents under
+   * most conditions.  However, given what SmokeDetector does with respect to pre-processing
+   * the HTML prior to working with it and sending the HTML to metasmoke, there are some,
+   * relatively rare, situations where it's impossible to recover the original HTML from
+   * what's stored in metasmoke.
+   */
+
+  function addPostPreviews() {
+    const previewPanels = $('.post-body-panel-preview > .panel > .panel-body:not(.javascript-generated)');
+    previewPanels.html(''); // Wipe any existing content
+    previewPanels.each(function () {
+      const previewBody = $(this);
+      const postSiteLink = previewBody.closest('.post-cell, .post-row, body .initial-content').find('.post-site-link');
+      const tabsBodyContainer = previewBody.closest('.body-content-container');
+      const reportedPostSDPreText = tabsBodyContainer.find('.post-body-panel-text .post-body-pre-block').text();
+      const divWithPreview = generatePostBodyDivFromHtmlText(reportedPostSDPreText, false);
+      pointRelativeURLsToSourceSESite(divWithPreview, { link: (postSiteLink[0] || { href: 'https://error--getting--site-link.foo/' }).href });
+      // Hide images
+      const hideImages = localStorage.hidePostPreviewImages !== 'false';
+      divWithPreview.find('img').each(function () {
+        const image = $(this);
+        if (hideImages) {
+          image
+            .one('click', event => {
+              image.attr('src', image.data('src'));
+              event.preventDefault();
+            });
+        }
+        else {
+          image.attr('src', image.data('src'));
+        }
+      });
+      // Add handlers for spoilers
+      divWithPreview.find('blockquote.spoiler')
+        .attr('data-spoiler', 'Reveal spoiler')
+        .one('click', function () {
+          $(this).addClass('is-visible');
+        });
+      previewBody
+        .addClass('javascript-generated')
+        .append(divWithPreview);
+    });
+  }
+
+  onLoad(addPostPreviews);
+  $(document).ajaxComplete(() => setTimeout(addPostPreviews, 10));
+
+  function addHideImagesLocalSetting() {
+    const content = $(`<h3>Hide Images in Post Previews</h3>
+    <div class="">
+      <p>This will prevent both downloading and viewing of inappropriate images in post previews, unless you click to view each image. This is enabled by default.</p>
+      <p>If enabled, the content of each image in a post preview will initially be a placeholder image. You will be able to click the placeholder image to display the original image. The original images will not be downloaded over the network unless the placeholder is clicked.</p>
+      <p>If disabled, images in the post preview will always be displayed. They will automatically be downloaded whenever the post preview tab is available, even if the post preview is not displayed.</p>
+      <input type="checkbox" name="hideImages" id="hideImages" checked="checked"> <label for="hideImages">Hide images in post preview panels initially with click to show image</label>
+    </div>`);
+    const hideImageInput = content.find('#hideImages');
+    hideImageInput.on('change', () => {
+      localStorage.hidePostPreviewImages = hideImageInput.is(':checked');
+    });
+    hideImageInput.prop('checked', localStorage.hidePostPreviewImages !== 'false');
+    addLocalSettingsPanel(content);
+  }
+
+  route('/users/edit', addHideImagesLocalSetting);
+
+  /* eslint-disable brace-style, capitalized-comments, comma-dangle, object-curly-spacing, arrow-parens */
+
+  // The following code was copied from FIRE (https://github.com/Charcoal-SE/userscripts/blob/master/fire/fire.user.js)
+  // by Makyen, the primary author for the copied code. It's under a dual Apache License 2.0 and MIT license.
+  // The intent is for the code below and the code in FIRE to remain in sync.
+
+  /**
+   * pointRelativeURLsToSourceSESite - In place, change relative link URLs to point to the source SE site.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {jQuery}    reportBody    jQuery Object containing the post body wrapped in a <div>.
+   * @param   {object}    postData      The data for the post.
+   */
+  function pointRelativeURLsToSourceSESite(reportBody, postData) {
+    // Convert relative URLs to point to the URL on the source site.
+    // SE uses these for tags and some site-specific functionality (e.g. circuit simulation on Electronics)
+    const [, siteHref] = (postData.link || '').match(/^((?:https?:)?\/\/(?:[a-z\d-]+\.)+[a-z\d-]+\/)/i) || ['', ''];
+    // A couple of reports which had this problem:
+    //   https://chat.stackexchange.com/transcript/11540?m=55601336#55601336  (links at bottom)
+    //   https://chat.stackexchange.com/transcript/11540?m=54674140#54674140  (tags)
+    reportBody.find('a').each(function () {
+      const $this = $(this);
+      let href = $this.attr('href');
+      if (!/^(?:[a-z]+:)?\/\//.test(href)) {
+        // It's not a fully qualified or protocol-relative link.
+        if (href.startsWith('/')) {
+          // The path is absolute
+          if (siteHref.endsWith('/')) {
+            href = href.replace('/', '');
+          }
+          this.href = siteHref + href;
+        } else {
+          // It's relative to the question (really shouldn't see any of these)
+          if (!siteHref.endsWith('/')) {
+            href = `/${href}`;
+          }
+          this.href = postData.link + href;
+        }
+      }
+    });
+  }
+
+  /**
+   * toHTMLEntitiesBetweenTags - Convert HTML tags to  &lt;tag text&gt; that are within the start and end of a specified tag.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {string}    toChange                The complete text to make changes within.
+   * @param   {string}    tagText                 The type of tag within which to make changes (e.g. "code")
+   * @param   {RegExp}    whiteListedTagsRegex    Falsy or a RegExp that is used to match tags which should be whitelisted inside the changed area.
+   *
+   * @returns {string}                            The changed text
+   */
+  function toHTMLEntitiesBetweenTags(toChange, tagText, whiteListedTagsRegex) {
+    let codeLevel = 0;
+    const tagRegex = new RegExp(`(</?${tagText}>)`, 'g');
+    const tagSplit = (toChange || '').split(tagRegex);
+    const tagBegin = `<${tagText}>`;
+    const tagEnd = `</${tagText}>`;
+    return tagSplit.reduce((text, split) => {
+      if (split === tagBegin) {
+        codeLevel++;
+        if (codeLevel === 1) {
+          return text + split;
+        }
+      } else if (split === tagEnd) {
+        codeLevel--;
+      }
+      if (codeLevel > 0) {
+        split = split.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        if (whiteListedTagsRegex) {
+          whiteListedTagsRegex.lastIndex = 0;
+          split = split.replace(whiteListedTagsRegex, '<$1>');
+        }
+      }
+      return text + split;
+    }, '');
+  }
+
+  // Many of the attributes permitted here are not permitted in Markdown for SE, but are delivered by SE in the HTML for the post body.
+  //   SE adds the additional attributes.
+  // For <a>, 'rel' is not permitted in Markdown, but is in SE's HTML.
+  // The Comprehensive Formatting Test:
+  //   https://chat.stackexchange.com/transcript/message/63128026#63128026
+  //   https://metasmoke.erwaysoftware.com/posts/by-url?url=//meta.stackexchange.com/a/325826
+  //   https://meta.stackexchange.com/a/325826
+  const whitelistedTags = {
+    withAttributes: {
+      blockquote: ['class'], // 'data-spoiler'], // data-spoiler is used on SE sites, but isn't in the HTML delivered by SE.
+      div: ['class', 'data-lang', 'data-hide', 'data-console', 'data-babel'],
+      ol: ['start'],
+      pre: ['class'],
+      span: ['class', 'dir'],
+      h1: ['id'],
+      h2: ['id'],
+      h3: ['id'],
+      h4: ['id'],
+      h5: ['id'],
+      h6: ['id'],
+    },
+    specialCases: {
+      a: {
+        general: ['title', 'rel', 'alt', 'aria-label', 'aria-labelledby', 'class'],
+        specificValues: {
+          class: ['post-tag', 'post-tag required-tag', 'post-tag moderator-tag'], // example post with tags: https://chat.stackexchange.com/transcript/11540?m=54674140#54674140
+          // rel probably has a limited set of values, but that really hasn't been explored, yet.
+          // rel: ['tag'], // example post with tags: https://chat.stackexchange.com/transcript/11540?m=54674140#54674140
+        },
+        // href must be relative, protocol-relative, http, or https.
+        // For <a>, SE only permits a limited subset of "href" values, so we can be more specific on these.
+        regexText: {href: '(?:https?:)?//?[^" ]*'},
+      },
+      iframe: {
+        // example: https://chat.stackexchange.com/transcript/11540?m=59301624#59301624
+        general: ['width', 'height'],
+        regexText: {src: 'https://(?:www\\.)?youtube\\.com/embed/[^" ]+'},
+      },
+      img: {
+        ordered: ['src', 'width', 'height', 'alt', 'title'],
+        isOptionallySelfClosing: true,
+      },
+      table: {specificValues: {class: ['s-table']}}, // example post with table: https://chat.stackoverflow.com/transcript/41570?m=51575339#51575339
+      td: {specificValues: {style: ['text-align: right;', 'text-align: left;', 'text-align: center;']}}, // example post with td: https://chat.stackoverflow.com/transcript/41570?m=51575339#51575339
+      th: {specificValues: {style: ['text-align: right;', 'text-align: left;', 'text-align: center;']}}, // example post with th: https://chat.stackoverflow.com/transcript/41570?m=51575339#51575339
+    },
+    optionallySelfClosingTagsWithNoAttributes: {
+      br: [],
+      hr: [],
+    },
+    withNoAttributes: {
+      b: [],
+      code: [],
+      dd: [],
+      del: [],
+      dl: [],
+      dt: [],
+      em: [],
+      i: [],
+      kbd: [],
+      li: [],
+      p: [],
+      s: [],
+      strike: [],
+      strong: [],
+      sub: [],
+      sup: [],
+      tbody: [],
+      thead: [],
+      tr: [],
+      ul: [],
+    },
+  };
+  const whitelistedAttributesByTagType = Object.assign({},
+    whitelistedTags.optionallySelfClosingTagsWithNoAttributes,
+    whitelistedTags.withNoAttributes,
+    whitelistedTags.withAttributes,
+    whitelistedTags.specialCases);
+
+  /*
+    sortJqueryByDepth is modified from an answer to "jQuery traversing order - depth first" : https://stackoverflow.com/a/5756066
+    Copyright 2011-04-22 16:27:08Z by alexl: https://stackoverflow.com/users/72562/alexl
+    licensed under CC BY-SA 3.0
+  */
+
+  /**
+   * sortJqueryByDepth - Sort the elements in a jQuery Object by depth, deepest first.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {jQuery}    input    The elements to sort
+   *
+   * @returns {jQuery}             New jQuery Object with the deepest elements first.
+   */
+  function sortJqueryByDepth(input) {
+    const allElements = input.map(function () {
+      return {length: $(this).parents().length, element: this};
+    }).get();
+    allElements.sort((a, b) => a.length - b.length);
+    return $(allElements.map(({element}) => element));
+  }
+
+  /**
+   * convertChildElementsWithNonWhitelistedAttributesToText - In place, convert to text all descendants of a container which have non-whitelisted attributes.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {jQuery}    container    The elements and their descendants to check.
+   *
+   */
+  function convertChildElementsWithNonWhitelistedAttributesToText(container) {
+    // Get all elements within a <div>
+    // Given that we might change some of the elements into text, this will allow us to get them again, if that occurs.
+    // This no longer assumes that the current location in the DOM of the elements in the input does not need to be maintained (i.e. they will be moved).
+    container = $(container);
+
+    /**
+     * convertElements - In place, one pass of converting to text the descendants of a container which have non-whitelisted attributes.
+     *
+     * @private
+     * @memberof module:fire
+     *
+     * @param   {jQuery}     elementsIn    The elements and their descendants to check.
+     *
+     * @returns {boolean}                  Flag indicating if any changes were made.
+     */
+    function convertElements(elementsIn) {
+      let didChange = false;
+      elementsIn.each(function () {
+        const attrList = [...this.attributes].map((attrNode) => attrNode.name.toLowerCase());
+        const nodeType = this.nodeName.toLowerCase();
+        const nodeTypeAttrList = whitelistedAttributesByTagType[nodeType];
+        let shouldReplaceThis = false;
+        if (!Array.isArray(nodeTypeAttrList) && typeof nodeTypeAttrList === 'object' && nodeTypeAttrList !== null) {
+          // This is a special case tag.
+          // Remove attributes which can have general values.
+          const nonGeneralAttrs = attrList.filter((attr) => !Array.isArray(nodeTypeAttrList.general) || !nodeTypeAttrList.general.includes(attr));
+          // Remove any which are specific values, where the value matches one which is permitted.
+          const nonSpecificAttrs = nonGeneralAttrs.filter((attr) => !nodeTypeAttrList.specificValues || !Array.isArray(nodeTypeAttrList.specificValues[attr]) || !nodeTypeAttrList.specificValues[attr].includes(this.attributes[attr].nodeValue));
+          const remainingAttrs = nonSpecificAttrs.filter((attr) => !nodeTypeAttrList.regexText || typeof nodeTypeAttrList.regexText[attr] !== 'string' || !(new RegExp(`^${nodeTypeAttrList.regexText[attr]}$`)).test(this.attributes[attr].nodeValue));
+          const remainingUnorderedAttrs = remainingAttrs.filter((attr) => !Array.isArray(nodeTypeAttrList.ordered) || !nodeTypeAttrList.ordered.includes(attr));
+          const remainingOrderedAttrs = remainingAttrs.filter((attr) => Array.isArray(nodeTypeAttrList.ordered) && nodeTypeAttrList.ordered.includes(attr));
+          let foundIndex = -1;
+          const areOrderedAttrsInOrder = remainingOrderedAttrs.every((attr) => {
+            const newFoundIndex = nodeTypeAttrList.ordered.indexOf(attr);
+            const newFoundIndexIsHigher = foundIndex < newFoundIndex;
+            foundIndex = newFoundIndex;
+            return newFoundIndexIsHigher;
+          });
+          shouldReplaceThis = remainingUnorderedAttrs.length > 0 || !areOrderedAttrsInOrder;
+        } else if (!Array.isArray(nodeTypeAttrList) || !attrList.every((attr) => nodeTypeAttrList.includes(attr))) {
+          // This isn't a valid tag
+          shouldReplaceThis = true;
+        }
+        if (shouldReplaceThis) {
+          const newOuterHTML = this.outerHTML.replace('<', '&lt;').replace(/<(\/[a-z\d]+>)$/, '&lt;$1');
+          this.outerHTML = newOuterHTML;
+          didChange = true;
+        }
+      });
+      return didChange;
+    }
+    let allChildren;
+    // Repeatedly do the conversion, until nothing is changed.
+    // This can still end up with the HTML parsed incorrectly, but shouldn't have any elements which are
+    // not whitelisted, or which are whitelisted element that have attributes which are not whitelisted.
+    do {
+      // Get all the elements again, and re-run the conversion.
+      allChildren = sortJqueryByDepth(container.find('*'));
+    } while (convertElements(allChildren));
+  }
+
+  const whiteListedSETagsRegex = (function () {
+    // https://regex101.com/r/90UJ2K/1
+    // https://regex101.com/r/9I7r9O/1
+    /* eslint-disable no-useless-escape */
+    const selfClosingBasicTagsRegexText = `(?:${Object.keys(whitelistedTags.optionallySelfClosingTagsWithNoAttributes).join('|')})\\s*/?`;
+    const basicTagsRegexText = `\/?(?:${Object.keys(whitelistedTags.withNoAttributes).join('|')})\\s*`;
+    const complexTagsClosingRegexText = `\/(?:${Object.keys(whitelistedTags.withAttributes).join('|')})\\s*`;
+    const complexTagsRegexText = `(?:${Object.entries(whitelistedTags.withAttributes)
+      .map(([tag, attrs]) => `(?:${tag}\\b(?: +(?:${attrs.join('|')})="[^"<>]*")*)`) // syntax highlighting fodder: "
+      .join('|')})\\s*`;
+    const specialCaseTagsClosingRegexText = `\/(?:${Object.keys(whitelistedTags.specialCases).join('|')})\\s*`;
+    /* eslint-enable no-useless-escape */
+    const specialCaseTagsRegexText = `(?:${Object.entries(whitelistedTags.specialCases).map(([tag, obj]) => {
+      const unordered = [];
+      if (Array.isArray(obj.general)) {
+        unordered.push(`(?:${(obj.general || []).join('|')})="[^"<>]*"`); // syntax highlighting fodder: "
+      }
+      if (obj.specificValues) {
+        unordered.push(Object.entries(obj.specificValues)
+          .map(([specificValueAttr, values]) => `${specificValueAttr}="(?:${values.join('|')})"`)
+          .join('|'));
+      }
+      if (obj.regexText) {
+        unordered.push(Object.entries(obj.regexText)
+          .map(([regexTextAttr, regexText]) => `${regexTextAttr}="${regexText}"`)
+          .join('|'));
+      }
+      let unorderedRegexText = '';
+      if (unordered.length > 0) {
+        unorderedRegexText = `(?:(?: +(?:${unordered.join('|')}))*)`;
+      }
+      let allAttrs = unorderedRegexText;
+      let orderedRegexText = '';
+      if (obj.ordered) {
+        orderedRegexText = `(?:(?: +${obj.ordered.join(`="[^"<>]*")?${unorderedRegexText}(?: +`)}="[^"<>]*")?)`;
+        allAttrs = unorderedRegexText + orderedRegexText + unorderedRegexText;
+      }
+      const attrRegexText = `(?:${tag}\\b${allAttrs}\\s*${obj.isOptionallySelfClosing ? '/?' : ''})`;
+      return attrRegexText;
+    })
+      .join('|')})`;
+    const fullRegexText = `&lt;(${[
+      selfClosingBasicTagsRegexText,
+      basicTagsRegexText,
+      complexTagsClosingRegexText,
+      complexTagsRegexText,
+      specialCaseTagsClosingRegexText,
+      specialCaseTagsRegexText,
+    ].join('|')})&gt;`;
+    return new RegExp(fullRegexText, 'gi');
+  })();
+  /* The whitelisted RegExp is currently:
+    2023-03-08:(https://regex101.com/r/6b7QBz/1)
+      /&lt;((?:br|hr)\s*\/?|\/?(?:b|code|dd|del|dl|dt|em|i|kbd|li|p|s|strike|strong|sub|sup|tbody|thead|tr|ul)\s*|\/(?:blockquote|div|ol|pre|span|h1|h2|h3|h4|h5|h6)\s*|(?:(?:blockquote\b(?: +(?:class)="[^"<>]*")*)|(?:div\b(?: +(?:class|data-lang|data-hide|data-console|data-babel)="[^"<>]*")*)|(?:ol\b(?: +(?:start)="[^"<>]*")*)|(?:pre\b(?: +(?:class)="[^"<>]*")*)|(?:span\b(?: +(?:class|dir)="[^"<>]*")*)|(?:h1\b(?: +(?:id)="[^"<>]*")*)|(?:h2\b(?: +(?:id)="[^"<>]*")*)|(?:h3\b(?: +(?:id)="[^"<>]*")*)|(?:h4\b(?: +(?:id)="[^"<>]*")*)|(?:h5\b(?: +(?:id)="[^"<>]*")*)|(?:h6\b(?: +(?:id)="[^"<>]*")*))\s*|\/(?:a|iframe|img|table|td|th)\s*|(?:(?:a\b(?:(?: +(?:(?:title|rel|alt|aria-label|aria-labelledby)="[^"<>]*"|class="(?:post-tag|post-tag required-tag|post-tag moderator-tag)"|href="(?:https?:)?\/\/?[^" ]*"))*)\s*)|(?:iframe\b(?:(?: +(?:(?:width|height)="[^"<>]*"|src="https:\/\/(?:www\.)?youtube\.com\/embed\/[^" ]+"))*)\s*)|(?:img\b(?:(?: +src="[^"<>]*")?(?: +width="[^"<>]*")?(?: +height="[^"<>]*")?(?: +alt="[^"<>]*")?(?: +title="[^"<>]*")?)\s*\/?)|(?:table\b(?:(?: +(?:class="(?:s-table)"))*)\s*)|(?:td\b(?:(?: +(?:style="(?:text-align: right;|text-align: left;|text-align: center;)"))*)\s*)|(?:th\b(?:(?: +(?:style="(?:text-align: right;|text-align: left;|text-align: center;)"))*)\s*)))&gt;/gi
+  */
+
+  /**
+   * getHtmlAsDOMWrappedInDiv - Generate a <div> containing the provided HTML text.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {string}          htmlText     The text to change into DOM nodes.
+   *
+   * @returns {DOM_node}                     <div> containing the DOM node representation of the HTML text.
+   */
+  function getHtmlAsDOMWrappedInDiv(htmlText) {
+    // If we just use jQuery to convert the HTML text to DOM, then the images are fetched, which might look suspicious if network traffic
+    //   is being monitored (e.g. in a work environment) and the image is NSFW. This avoids that happening until such time as the elements
+    //   are placed in the page DOM. Prior to that happening, we change the URL for images, if the user hasn't selected not to do so.
+    // This also prevents various code execution attack vectors which don't function when the new nodes are not elements created in
+    //   the page DOM. However, such code *IS* executed if the newly created nodes are just placed in the page DOM, even after this.
+    //   Thus, it's necessary for subsequent processing to remove those types of attack vectors.
+    // The htmlText may be malformed, so we wrap it in a div after conversion to DOM nodes.
+    const parser = new DOMParser();
+    const htmlAsDOM = parser.parseFromString(htmlText, 'text/html');
+    // The body here will often have multiple child nodes. We want everything wrapped in a div, so:
+    const newDiv = htmlAsDOM.createElement('div');
+    newDiv.append(...htmlAsDOM.body.childNodes);
+    return newDiv;
+  }
+
+  /**
+   * generatePostBodyDivFromHtmlText - Generate a <div> containing the HTML for a post body from HTML text.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {string}          htmlText     The text to change into HTML.
+   * @param   {truthy/falsy}    isTrusted    Truthy if the text supplied is from SE (i.e. it's trusted / not pre-processed by SD).
+   *
+   * @returns {jQuery}                       <div> containing the body HTML.
+   */
+  function generatePostBodyDivFromHtmlText(htmlText, isTrusted) {
+    // Just having the whitelisted tags active is good, but results in the possibility that we've enabled
+    //   a tag within <code>.
+    // div and pre can have class and other attributes for snippets.
+
+    // SE normally provides HTML with <code> sections having <, >, and & (???) replaced by their HTML entities. The .body we get from MS has all HTML entities
+    //   throughout the text (not just in <code> and <blockquote>) replaced with their Unicode characters
+    //   This is done to facilitate regex matching within the post, particularly within <code>.
+    //   With what SD has done to the text it's not, necessarily, possible to
+    //   recover back to the actual content (e.g. what happens with Markdown like `<code>`: SE would send "<code>&lt;code&gt;</code>", but that gets converted
+    //   to "<code><code></code>" by SD/MS. In addition, it's possible there were originally other pieces of text which were HTML entities that are now
+    //   Unicode characters which are incorrectly interpreted as valid HTML tags, etc.
+    //   So, ultimately, the conversion from the body stored on MS to HTML text which we do here is, at best, an approximation. However, it's considerably
+    //   better than not trying to perform that conversion at all.
+    /*
+      `<code>` foobar `</code>`
+      produces
+      <code>&lt;code&gt;</code> foobar <code>&lt;/code&gt;</code>
+      processed:
+      <code><code></code> foobar <code></code></code>
+
+      `<code></code> foobar <code></code>`
+      produces
+      <code>&lt;code&gt;&lt;/code&gt; foobar &lt;code&gt;&lt;/code&gt;</code>
+      processed:
+      <code><code></code> foobar <code></code></code>
+
+          */
+    // What we have in the MS provided body is that the <code> sections have had all of the &gt;, &lt; and ? &amp; ? changed to actual characters, rather than the
+    //   HTML entities, which is what SE provides. So, in order to display it (or compare it to what SE provides), we need to convert all of those back to the
+    //   HTML entities. If we don't, then what's displayed could be incorrect.
+    // At this point, it's reasonably consistently formatted HTML, due to being processed from Markdown by SE.
+    // On deleted posts where the MS data isn't available, d.body could be undefined.
+
+    let processedBody = htmlText;
+    if (!isTrusted) {
+      // If we are converting HTML text received from SE, then we don't need to handle the HTML
+      //   entities having been converted to Unicode characters. We can just use the HTML text directly.
+      whiteListedSETagsRegex.lastIndex = 0;
+      const bodyOnlyWhitelist = $('<div/>')
+        .text(htmlText || '') // Escape everything. NOTE: Everything should be unescaped coming from SD/MS, but properly formatted if it's from SE.
+        .html() // Get the escaped HTML, unescape whitelisted tags.
+        .replace(whiteListedSETagsRegex, '<$1>');
+      processedBody = toHTMLEntitiesBetweenTags(bodyOnlyWhitelist, 'code');
+      processedBody = toHTMLEntitiesBetweenTags(processedBody, 'blockquote', whiteListedSETagsRegex);
+    }
+    // At this point, if we just pass the HTML to jQuery, then the images are fetched, which might look suspicious if network traffic is being monitored
+    //   (e.g. in a work environment) and the image is NSFW. Still need to avoid that.
+    // ProcessedBody may be malformed, so we don't wrap it in a div in HTML text.
+    const containingDiv = getHtmlAsDOMWrappedInDiv(processedBody);
+    if (!isTrusted) {
+      convertChildElementsWithNonWhitelistedAttributesToText(containingDiv);
+    }
+    // Change all the image src prior to inserting into main document DOM or letting jQuery see it.
+    // Not doing that here would result in the browser making fetches for each image's URL, which
+    // could be bad for NSFW images in some situations (e.g. someone using this from work).
+    // We could do this in the HTML text, but we want a DOM anyway, and it's easier to do it as DOM.
+    containingDiv.querySelectorAll('img').forEach((image) => {
+      image.dataset.src = image.src;
+      image.src = 'https://via.placeholder.com/550x100//ffffff?text=Click+to+show+image.';
+    });
+    return $(containingDiv);
+  }
+  /* eslint-enable */
+})();

--- a/app/javascript/post_preview.js
+++ b/app/javascript/post_preview.js
@@ -173,9 +173,9 @@ import { onLoad, route, addLocalSettingsPanel } from './util';
     },
     specialCases: {
       a: {
-        general: ['title', 'rel', 'alt', 'aria-label', 'aria-labelledby', 'class'],
+        general: ['title', 'rel', 'alt', 'aria-label', 'aria-labelledby', 'data-onebox-id'],
         specificValues: {
-          class: ['post-tag', 'post-tag required-tag', 'post-tag moderator-tag'], // example post with tags: https://chat.stackexchange.com/transcript/11540?m=54674140#54674140
+          class: ['post-tag', 'post-tag required-tag', 'post-tag moderator-tag', 'onebox-link'], // example post with tags: https://chat.stackexchange.com/transcript/11540?m=54674140#54674140
           // rel probably has a limited set of values, but that really hasn't been explored, yet.
           // rel: ['tag'], // example post with tags: https://chat.stackexchange.com/transcript/11540?m=54674140#54674140
         },
@@ -376,8 +376,8 @@ import { onLoad, route, addLocalSettingsPanel } from './util';
     return new RegExp(fullRegexText, 'gi');
   })();
   /* The whitelisted RegExp is currently:
-    2023-03-08:(https://regex101.com/r/6b7QBz/1)
-      /&lt;((?:br|hr)\s*\/?|\/?(?:b|code|dd|del|dl|dt|em|i|kbd|li|p|s|strike|strong|sub|sup|tbody|thead|tr|ul)\s*|\/(?:blockquote|div|ol|pre|span|h1|h2|h3|h4|h5|h6)\s*|(?:(?:blockquote\b(?: +(?:class)="[^"<>]*")*)|(?:div\b(?: +(?:class|data-lang|data-hide|data-console|data-babel)="[^"<>]*")*)|(?:ol\b(?: +(?:start)="[^"<>]*")*)|(?:pre\b(?: +(?:class)="[^"<>]*")*)|(?:span\b(?: +(?:class|dir)="[^"<>]*")*)|(?:h1\b(?: +(?:id)="[^"<>]*")*)|(?:h2\b(?: +(?:id)="[^"<>]*")*)|(?:h3\b(?: +(?:id)="[^"<>]*")*)|(?:h4\b(?: +(?:id)="[^"<>]*")*)|(?:h5\b(?: +(?:id)="[^"<>]*")*)|(?:h6\b(?: +(?:id)="[^"<>]*")*))\s*|\/(?:a|iframe|img|table|td|th)\s*|(?:(?:a\b(?:(?: +(?:(?:title|rel|alt|aria-label|aria-labelledby)="[^"<>]*"|class="(?:post-tag|post-tag required-tag|post-tag moderator-tag)"|href="(?:https?:)?\/\/?[^" ]*"))*)\s*)|(?:iframe\b(?:(?: +(?:(?:width|height)="[^"<>]*"|src="https:\/\/(?:www\.)?youtube\.com\/embed\/[^" ]+"))*)\s*)|(?:img\b(?:(?: +src="[^"<>]*")?(?: +width="[^"<>]*")?(?: +height="[^"<>]*")?(?: +alt="[^"<>]*")?(?: +title="[^"<>]*")?)\s*\/?)|(?:table\b(?:(?: +(?:class="(?:s-table)"))*)\s*)|(?:td\b(?:(?: +(?:style="(?:text-align: right;|text-align: left;|text-align: center;)"))*)\s*)|(?:th\b(?:(?: +(?:style="(?:text-align: right;|text-align: left;|text-align: center;)"))*)\s*)))&gt;/gi
+    2023-03-10:(https://regex101.com/r/YCHmek/1)
+      &lt;((?:br|hr)\s*\/?|\/?(?:b|code|dd|del|dl|dt|em|i|kbd|li|p|s|strike|strong|sub|sup|tbody|thead|tr|ul)\s*|\/(?:blockquote|div|ol|pre|span|h1|h2|h3|h4|h5|h6)\s*|(?:(?:blockquote\b(?: +(?:class)="[^"<>]*")*)|(?:div\b(?: +(?:class|data-lang|data-hide|data-console|data-babel)="[^"<>]*")*)|(?:ol\b(?: +(?:start)="[^"<>]*")*)|(?:pre\b(?: +(?:class)="[^"<>]*")*)|(?:span\b(?: +(?:class|dir)="[^"<>]*")*)|(?:h1\b(?: +(?:id)="[^"<>]*")*)|(?:h2\b(?: +(?:id)="[^"<>]*")*)|(?:h3\b(?: +(?:id)="[^"<>]*")*)|(?:h4\b(?: +(?:id)="[^"<>]*")*)|(?:h5\b(?: +(?:id)="[^"<>]*")*)|(?:h6\b(?: +(?:id)="[^"<>]*")*))\s*|\/(?:a|iframe|img|table|td|th)\s*|(?:(?:a\b(?:(?: +(?:(?:title|rel|alt|aria-label|aria-labelledby|data-onebox-id)="[^"<>]*"|class="(?:post-tag|post-tag required-tag|post-tag moderator-tag|onebox-link)"|href="(?:https?:)?\/\/?[^" ]*"))*)\s*)|(?:iframe\b(?:(?: +(?:(?:width|height)="[^"<>]*"|src="https:\/\/(?:www\.)?youtube\.com\/embed\/[^" ]+"))*)\s*)|(?:img\b(?:(?: +src="[^"<>]*")?(?: +width="[^"<>]*")?(?: +height="[^"<>]*")?(?: +alt="[^"<>]*")?(?: +title="[^"<>]*")?)\s*\/?)|(?:table\b(?:(?: +(?:class="(?:s-table)"))*)\s*)|(?:td\b(?:(?: +(?:style="(?:text-align: right;|text-align: left;|text-align: center;)"))*)\s*)|(?:th\b(?:(?: +(?:style="(?:text-align: right;|text-align: left;|text-align: center;)"))*)\s*)))&gt;
   */
 
   /**

--- a/app/javascript/post_preview.js
+++ b/app/javascript/post_preview.js
@@ -75,44 +75,6 @@ import { onLoad, route, addLocalSettingsPanel } from './util';
   // The intent is for the code below and the code in FIRE to remain in sync.
 
   /**
-   * pointRelativeURLsToSourceSESite - In place, change relative link URLs to point to the source SE site.
-   *
-   * @private
-   * @memberof module:fire
-   *
-   * @param   {jQuery}    reportBody    jQuery Object containing the post body wrapped in a <div>.
-   * @param   {object}    postData      The data for the post.
-   */
-  function pointRelativeURLsToSourceSESite(reportBody, postData) {
-    // Convert relative URLs to point to the URL on the source site.
-    // SE uses these for tags and some site-specific functionality (e.g. circuit simulation on Electronics)
-    const [, siteHref] = (postData.link || '').match(/^((?:https?:)?\/\/(?:[a-z\d-]+\.)+[a-z\d-]+\/)/i) || ['', ''];
-    // A couple of reports which had this problem:
-    //   https://chat.stackexchange.com/transcript/11540?m=55601336#55601336  (links at bottom)
-    //   https://chat.stackexchange.com/transcript/11540?m=54674140#54674140  (tags)
-    reportBody.find('a').each(function () {
-      const $this = $(this);
-      let href = $this.attr('href');
-      if (!/^(?:[a-z]+:)?\/\//.test(href)) {
-        // It's not a fully qualified or protocol-relative link.
-        if (href.startsWith('/')) {
-          // The path is absolute
-          if (siteHref.endsWith('/')) {
-            href = href.replace('/', '');
-          }
-          this.href = siteHref + href;
-        } else {
-          // It's relative to the question (really shouldn't see any of these)
-          if (!siteHref.endsWith('/')) {
-            href = `/${href}`;
-          }
-          this.href = postData.link + href;
-        }
-      }
-    });
-  }
-
-  /**
    * toHTMLEntitiesBetweenTags - Convert HTML tags to  &lt;tag text&gt; that are within the start and end of a specified tag.
    *
    * @private
@@ -479,6 +441,44 @@ import { onLoad, route, addLocalSettingsPanel } from './util';
       image.src = 'https://via.placeholder.com/550x100//ffffff?text=Click+to+show+image.';
     });
     return $(containingDiv);
+  }
+
+  /**
+   * pointRelativeURLsToSourceSESite - In place, change relative link URLs to point to the source SE site.
+   *
+   * @private
+   * @memberof module:fire
+   *
+   * @param   {jQuery}    reportBody    jQuery Object containing the post body wrapped in a <div>.
+   * @param   {object}    postData      The data for the post.
+   */
+  function pointRelativeURLsToSourceSESite(reportBody, postData) {
+    // Convert relative URLs to point to the URL on the source site.
+    // SE uses these for tags and some site-specific functionality (e.g. circuit simulation on Electronics)
+    const [, siteHref] = (postData.link || '').match(/^((?:https?:)?\/\/(?:[a-z\d-]+\.)+[a-z\d-]+\/)/i) || ['', ''];
+    // A couple of reports which had this problem:
+    //   https://chat.stackexchange.com/transcript/11540?m=55601336#55601336  (links at bottom)
+    //   https://chat.stackexchange.com/transcript/11540?m=54674140#54674140  (tags)
+    reportBody.find('a').each(function () {
+      const $this = $(this);
+      let href = $this.attr('href');
+      if (!/^(?:[a-z]+:)?\/\//.test(href)) {
+        // It's not a fully qualified or protocol-relative link.
+        if (href.startsWith('/')) {
+          // The path is absolute
+          if (siteHref.endsWith('/')) {
+            href = href.replace('/', '');
+          }
+          this.href = siteHref + href;
+        } else {
+          // It's relative to the question (really shouldn't see any of these)
+          if (!siteHref.endsWith('/')) {
+            href = `/${href}`;
+          }
+          this.href = postData.link + href;
+        }
+      }
+    });
   }
   /* eslint-enable */
 })();

--- a/app/javascript/util.js
+++ b/app/javascript/util.js
@@ -205,3 +205,27 @@ export function hashCode(str) {
   }
   return hash;
 }
+
+// Local Settings panel
+export function addLocalSettingsHeaderToAccount() {
+  if ($('.local-settings-panels-container').length === 0) {
+    $('div.row').append(`<br style="clear: both;">
+    <h2 class="text-center">Local Browser Settings</h2>
+    <p class="text-center">These settings apply only to the current browser.</p>
+    <div class="row local-settings-row">
+      <div class="col-md-8 col-md-offset-2 local-settings-panels-container">
+      </div>
+    </div>`);
+  }
+}
+
+export function addLocalSettingsPanel(content) {
+  addLocalSettingsHeaderToAccount();
+  const panelsContainer = $('.local-settings-panels-container');
+  const panel = $(`<div class="panel panel-default">
+    <div class="panel-body">
+    </div>
+  </div>`);
+  panel.find('.panel-body').append(content);
+  panelsContainer.append(panel);
+}

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -101,7 +101,6 @@
           <div role="tabpanel" class="tab-pane post-body-panel-preview" id="preview-tab-<%= post.id %>">
             <div class="panel panel-default">
               <div class="panel-body">
-                <%= safe_render_markdown(post.markdown || post.body, scrubber: Post.scrubber) %>
               </div>
             </div>
           </div>

--- a/app/views/posts/body.html.erb
+++ b/app/views/posts/body.html.erb
@@ -31,7 +31,6 @@
   <div role="tabpanel" class="tab-pane post-body-panel-preview" id="preview-tab-<%= @post.id %>">
     <div class="panel panel-default">
       <div class="panel-body">
-        <%= safe_render_markdown(@post.markdown || @post.body, scrubber: Post.scrubber) %>
       </div>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -97,7 +97,6 @@
     <div role="tabpanel" class="tab-pane post-body-panel-preview" id="preview-tab">
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= safe_render_markdown(@post.markdown || @post.body, scrubber: Post.scrubber) %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This implements very similar logic to how FIRE handles images. By default, images are shown as a placeholder image, which the user can click to display. If clicked, the original image is displayed. In order to not have the images displayed, the generation of the post preview is moved into JavaScript, so the `<img>` is never in the DOM with the `src` attribute set to the original value unless the user has clicked on the placeholder. A setting is available in a new section on the "Account Settings" page for users to disable this feature and always show images.

The majority of the preview generation code is shared with FIRE, which was already doing the conversion from SD processed HTML to HTML which can be viewed.

As in FIRE, the HTML elements and attribute values are restricted to those which SE permits and/or generates.