### PR TITLE
Fixed team URL

### DIFF
--- a/app/views/channels/get_email_address.html.erb
+++ b/app/views/channels/get_email_address.html.erb
@@ -1,5 +1,5 @@
 <h1>Channels: Email address</h1>
 <p>The following is your email address to use with Channels. Copy and paste it into the box at
-  <a href="https://stackoverflow.com/c/charcoal/join">stackoverflow.com/c/charcoal/join</a>.</p>
+  <a href="https://stackoverflowteams.com/c/charcoal/join">stackoverflowteams.com/c/charcoal/join</a>.</p>
 <input type="text" class="form-control" value="<%= @secret %>@channel-verify.charcoal-se.org" /><br/>
 <%= link_to 'Okay, done it', channels_link_path, class: 'btn btn-success' %>


### PR DESCRIPTION
Fixed the team URL due to the `stackoverflow.com` domain not redirecting anymore