### PR TITLE
Remove use of DOMNodeInserted in our code

### DIFF
--- a/app/javascript/post_preview.js
+++ b/app/javascript/post_preview.js
@@ -47,6 +47,8 @@ import { onLoad, route, addLocalSettingsPanel } from './util';
     });
   }
 
+  // The following is similar to what's used to select the post tab in application.js. If a change is needed here,
+  // then one is very likely to be needed there too.
   onLoad(addPostPreviews);
   $(document).ajaxComplete(() => setTimeout(addPostPreviews, 10));
   $(window).on('MS-review-loaded', addPostPreviews);


### PR DESCRIPTION
Chrome removed use of DOMNodeInserted event. We currently explicitly use that event only to show the appropriate tab for post bodies. We already have code that executes when post bodies are added to the DOM in order to render the post preview. The code to detect when a post body is added to the DOM is effectively duplicated here to select the correct tab.

NOTE: This is not as generically effective as a MutationObserver watching for all DOM node insertions in the `<body>` would be, but is substantially more efficient. The main drawback is that if a new way to add a post body is added to the code base, it may be necessary to add additional way(s) to detect that the post body has been added to the DOM (such as the special case used for the review pages).

In addition, this may not remove all uses of the DOM node events which Chrome has removed, as I have not, yet, checked to see if any of our dependencies use those events.