### PR TITLE
Github Actions: upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Run tests
       run: bundle exec rails test --verbose
     - name: Upload Gemfile.lock
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: Gemfile.lock
@@ -142,7 +142,7 @@ jobs:
       if: ${{ failure() }}
       run: git diff Gemfile.lock
     - name: Upload coverage data
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ success() }}
       with:
         name: coverage


### PR DESCRIPTION
v2 is no longer supported and has been causing tests to fail

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/